### PR TITLE
Defib the DB connection every 5 minutes

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -212,6 +212,22 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	sleep(1)
 
 	initializations_finished_with_no_players_logged_in = initialized_tod < REALTIMEOFDAY - 10
+
+	// query the DB once every five minutes to keep the connection alive
+	if(GLOB.dbcon.IsConnected())
+		spawn while(1)
+			log_and_message_admins("Keeping MySQL Alive...")
+			var/DBQuery/query = GLOB.dbcon.NewQuery("SELECT 1")
+			query.Execute()
+			var/db_constant = 0
+			while(query.NextRow())
+				db_constant = query.item[1]
+			if(db_constant != "1")
+				log_and_message_admins("Houston, we have a problem... [db_constant]")
+			sleep(3000)
+	else
+		log_and_message_admins("MySQL not connected. Will not execute heartbeat queries.")
+
 	// Loop.
 	Master.StartProcessing(0)
 


### PR DESCRIPTION
## What Does This PR Do
* Adds a low-impact background thread to query the database every 5 minutes.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
* If not exercised, MySQL connections will time out and then the game breaks in interesting ways.
* Normally, a consistent population would drive DB queries and keep the database alive.
* While we test and get Scorpio Station ready for public release, this prevents the game from breaking between testing sessions.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
