### PR TITLE
Revert "Defib the DB connection every 5 minutes"

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -212,22 +212,6 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	sleep(1)
 
 	initializations_finished_with_no_players_logged_in = initialized_tod < REALTIMEOFDAY - 10
-
-	// query the DB once every five minutes to keep the connection alive
-	if(GLOB.dbcon.IsConnected())
-		spawn while(1)
-			log_and_message_admins("Keeping MySQL Alive...")
-			var/DBQuery/query = GLOB.dbcon.NewQuery("SELECT 1")
-			query.Execute()
-			var/db_constant = 0
-			while(query.NextRow())
-				db_constant = query.item[1]
-			if(db_constant != "1")
-				log_and_message_admins("Houston, we have a problem... [db_constant]")
-			sleep(3000)
-	else
-		log_and_message_admins("MySQL not connected. Will not execute heartbeat queries.")
-
 	// Loop.
 	Master.StartProcessing(0)
 


### PR DESCRIPTION
Reverts ScorpioStation/ScorpioStation#6

This code was very useful for debugging, but is no longer necessary.

**Background**
The server would lose connection to the database, with an error message `MySQL server has gone away`. This would trap new connections in an endless loop of the Terms of Service / Consent dialog. The code was added to help troubleshoot that issue.

**Observations**
After a failed test, I decreased the time between heartbeats to keep the MySQL connection alive to 1 minute. Even after doing this, the game would pause its activity when nobody was connected. The following log snippet shows a ~5 hour gap between heartbeats.

```text
[2020-05-06 02:38:26.705] ADMIN: INVALID/(INVALID) Keeping MySQL Alive...
[2020-05-06 02:39:26.726] ADMIN: INVALID/(INVALID) Keeping MySQL Alive...
[2020-05-06 02:40:26.725] ADMIN: INVALID/(INVALID) Keeping MySQL Alive...
[2020-05-06 07:18:38.275] ADMIN: INVALID/(INVALID) Keeping MySQL Alive...
[2020-05-06 07:19:38.298] ADMIN: INVALID/(INVALID) Keeping MySQL Alive...
[2020-05-06 07:20:38.396] ADMIN: INVALID/(INVALID) Keeping MySQL Alive...
```

This means the heartbeats would be ineffective at keeping the connection alive.

**Research**
Turns out there are a lot of reasons for MySQL to lose the connection and send that error:
* https://haydenjames.io/mysql-server-has-gone-away-error-solutions/

There is even a page in the official MySQL documentation about troubleshooting this error:
* https://dev.mysql.com/doc/refman/8.0/en/gone-away.html

While the causes varied, the most common advice was to increase both `wait_timeout` and `max_allowed_packet` in the MySQL configuration files.

**Actions**
I looked in the MariaDB docker container and found the configuration at `/etc/mysql/my.cnf`:

```text
#
# * Fine Tuning
#
max_connections         = 100
connect_timeout         = 5
wait_timeout            = 600
max_allowed_packet      = 16M
thread_cache_size       = 128
sort_buffer_size        = 4M
bulk_insert_buffer_size = 16M
tmp_table_size          = 32M
max_heap_table_size     = 32M
```

I changed the two configuration variables to these values instead:
```text
wait_timeout        = 28800
max_allowed_packet    = 128M
```

**Results**
And after sleeping overnight, the server was still connected to the database and doing fine. The heartbeats weren't necessary to keep the server connected, but they did show that the configuration change allowed the connection to survive ~5 hours without input from the server.

This PR is to remove the heartbeat code that we no longer need.
Thank you for your service. ^^