### PR TITLE
Putting the Grey back in Greytide

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -84,6 +84,7 @@
 	var/list_afk_minimum = 5 // How long people have to be AFK before it's listed on the "List AFK players" verb
 
 	var/traitor_objectives_amount = 2
+	var/grey_assistants = 0
 	var/shadowling_max_age = 0
 
 	var/max_maint_drones = 5				//This many drones can spawn,
@@ -778,6 +779,8 @@
 					config.shuttle_refuel_delay     = text2num(value)
 				if("traitor_objectives_amount")
 					config.traitor_objectives_amount = text2num(value)
+				if("grey_assistants")
+					config.grey_assistants = 1
 				if("reactionary_explosions")
 					config.reactionary_explosions	= 1
 				if("bombcap")

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -7,9 +7,9 @@
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
-	access = list()			//See /datum/job/assistant/get_access()
-	minimal_access = list()	//See /datum/job/assistant/get_access()
-	alt_titles = list("Tourist","Businessman","Trader","Assistant")
+	access = list()         //See /datum/job/assistant/get_access()
+	minimal_access = list() //See /datum/job/assistant/get_access()
+	alt_titles = list("Assistant", "Businessman", "Tourist", "Trader")
 	outfit = /datum/outfit/job/assistant
 
 /datum/job/civilian/get_access()
@@ -25,4 +25,7 @@
 	uniform = /obj/item/clothing/under/color/random
 	shoes = /obj/item/clothing/shoes/black
 
-
+/datum/outfit/job/assistant/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(config.grey_assistants)
+		uniform = /obj/item/clothing/under/color/grey

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -41,6 +41,9 @@ REACTIONARY_EXPLOSIONS
 # Not including escaping/hijacking.
 TRAITOR_OBJECTIVES_AMOUNT 2
 
+## Uncomment to bring back old grey suit assistants instead of the now default rainbow colored assistants.
+#GREY_ASSISTANTS
+
 ### Configure the bomb cap
 ## This caps all explosions to the specified range. Used for both balance reasons and to prevent overloading the server and lagging the game out.
 ## This is given as the 3rd number(light damage) in the standard (1,2,3) explosion notation. The other numbers are derived by dividing by 2 and 4.
@@ -58,7 +61,6 @@ BOMBCAP 20
 ## This controls what the AI's laws are at the start of the round.
 ## Set to 0/commented for "off", silicons will just start with Crewsimov.
 ## Set to 1 for "random", silicons will start with a random lawset picked from (at the time of writing): Ark Soft Default, P.A.L.A.D.I.N., Corporate, Robop and Crewsimov. More can be added by changing the law datum "default" variable in ai_laws.dm.
-
 DEFAULT_LAWS 1
 
 ## Randomize roundstart time (anywhere from 00:00 to 23:00 instead of always starting at 12:00)

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -41,8 +41,9 @@ REACTIONARY_EXPLOSIONS
 # Not including escaping/hijacking.
 TRAITOR_OBJECTIVES_AMOUNT 2
 
-## Uncomment to bring back old grey suit assistants instead of the now default rainbow colored assistants.
-#GREY_ASSISTANTS
+## Comment to use rainbow colored suits for assistants
+## Uncomment to use classic grey suits for assistants
+GREY_ASSISTANTS
 
 ### Configure the bomb cap
 ## This caps all explosions to the specified range. Used for both balance reasons and to prevent overloading the server and lagging the game out.


### PR DESCRIPTION
## What Does This PR Do
Adds a new option `GREY_ASSISTANTS` in the configuration file `game_options.txt`.

When uncommented, this option overrides the random color jumpsuits assigned to assistants and replaces it with the classic grey jumpsuit. This option puts the grey back in greytide.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The greytide are a classic element of SS13. Also, Ark Soft got a really sweet discount buying grey uniforms in bulk from Nanotrasen.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
