### PR TITLE
Gives Arrivals airlocks sounds for opening and closing

### DIFF
--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -16,5 +16,45 @@
 	return
 
 /obj/machinery/door/unpowered/shuttle
+	var/soundsopen = 'sound/machines/airlock_open.ogg'
+	var/soundsclosed = 'sound/machines/airlock_close.ogg'
 	icon = 'icons/turf/shuttle.dmi'
 	icon_state = "door1"
+
+/obj/machinery/door/unpowered/shuttle/open()
+	playsound(loc, soundsopen, 30, 1)
+	. = ..()
+
+/obj/machinery/door/unpowered/shuttle/close()
+	if(density)
+		return TRUE
+	if(operating || welded)
+		return
+	if(safe)
+		for(var/turf/turf in locs)
+			for(var/atom/movable/M in turf)
+				if(M.density && M != src) //something is blocking the door
+					if(autoclose)
+						autoclose_in(60)
+					return
+
+	operating = TRUE
+
+	playsound(loc, soundsclosed, 30, 1)
+	do_animate("closing")
+	layer = closingLayer
+	sleep(5)
+	density = TRUE
+	sleep(5)
+	update_icon()
+	if(visible && !glass)
+		set_opacity(1)
+	operating = 0
+	air_update_turf(1)
+	update_freelook_sight()
+	if(safe)
+		CheckForMobs()
+	else
+		crush()
+	return TRUE
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Gives the arrivals shuttle airlocks a sound for opening and closing. This sound is identical to the normal airlock opening and closing sound.
Solves #31
Gives the arrivals airlock a sound for opening and closing. This sound is identical to the sound a normal airlock makes when opened and closed.
Solves
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The arrivals shuttle airlocks should have opening and closing sounds, just like every other airlock.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: fixes how the arrivals shuttle airlocks doesn't have opening and closing sounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
