### PR TITLE
Running our container as the ss13 user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,20 +62,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 #
+# Create a user to own the files
+#
+RUN useradd -ms /bin/bash ss13
+
+#
 # Copy things into the docker image
 #
-COPY . /scorpio
-COPY --from=byond_build /byond /byond
-COPY --from=byond_build /scorpio/paradise.dmb /scorpio/paradise.dmb
-COPY --from=byond_build /scorpio/paradise.rsc /scorpio/paradise.rsc
-COPY --from=rust-g:latest /rust-g/target/release/librust_g.so /scorpio/librust_g.so
-COPY --from=mariadb_library /usr/lib/i386-linux-gnu/libmariadb.so /scorpio/libmariadb.so
+COPY --chown=ss13:ss13 . /scorpio
+COPY --chown=ss13:ss13 --from=byond_build /byond /byond
+COPY --chown=ss13:ss13 --from=byond_build /scorpio/paradise.dmb /scorpio/paradise.dmb
+COPY --chown=ss13:ss13 --from=byond_build /scorpio/paradise.rsc /scorpio/paradise.rsc
+COPY --chown=ss13:ss13 --from=rust-g:latest /rust-g/target/release/librust_g.so /scorpio/librust_g.so
+COPY --chown=ss13:ss13 --from=mariadb_library /usr/lib/i386-linux-gnu/libmariadb.so /scorpio/libmariadb.so
 
 #
 # Configure the runtime environment for the docker image
 #
 ENV LD_LIBRARY_PATH="/scorpio:/byond/bin:${LD_LIBRARY_PATH}"
 ENV PATH="/byond/bin:${PATH}"
+USER ss13
 WORKDIR /scorpio
 
 #

--- a/docker-init-db
+++ b/docker-init-db
@@ -2,7 +2,7 @@
 # initialize a MariaDB container to act as a database for Scorpio Station
 
 # generate some secure passwords
-DB_VERSION="11"
+DB_VERSION="12"
 MYSQL_DATABASE="scorpio"
 MYSQL_PASSWORD=$(dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 | head -c 32)
 MYSQL_ROOT_PASSWORD=$(dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 | head -c 32)


### PR DESCRIPTION
## What Does This PR Do
* Bumps the version in the `docker-init-db` script to match the current DB version (12)
* Modifies the `Dockerfile` to run the server as the user `ss13` instead of `root`
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
* Keeping scripts up to date keeps them useful and avoids bug reports.
* Running as a regular user instead of root is good security practice.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
