### PR TITLE
Changed the old bard perset to a new Popstar preset

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -503,8 +503,8 @@
 
 
 
-/datum/outfit/admin/musician
-	name = "Musician"
+/datum/outfit/admin/popstar
+	name = "Popstar"
 
 	uniform = /obj/item/clothing/under/singerb
 	back = /obj/item/storage/backpack
@@ -519,22 +519,16 @@
 		/obj/item/flashlight = 1,
 		/obj/item/instrument/violin = 1,
 		/obj/item/instrument/piano_synth = 1,
-		/obj/item/instrument/guitar = 1,
-		/obj/item/instrument/eguitar = 1,
-		/obj/item/instrument/accordion = 1,
-		/obj/item/instrument/saxophone = 1,
-		/obj/item/instrument/trombone = 1,
-		/obj/item/instrument/harmonica = 1
 	)
 
-/datum/outfit/admin/musician/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/admin/popstar/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(visualsOnly)
 		return
 
 	var/obj/item/card/id/I = H.wear_id
 	if(istype(I))
-		apply_to_card(I, H, list(ACCESS_MAINT_TUNNELS), "Bard")
+		apply_to_card(I, H, list(ACCESS_MAINT_TUNNELS), "Popstar")
 
 	var/obj/item/clothing/ears/headphones/P = r_ear
 	if(istype(P))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Edits the preset for the old Bard to the new Popstar. It now only has the synth as well as the violin. The old version of this was rarely used, and this new one will allow stuff like our favorite Popstart Koolo to have a preset. And therefore also some popstar themed events
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Possibilities 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

![dreamseeker_HYho1UFul7](https://user-images.githubusercontent.com/59520813/83955097-b3c2eb00-a84f-11ea-8ed6-971f9a987fcd.png)

![dreamseeker_Jnxeg2GMd0](https://user-images.githubusercontent.com/59520813/83955098-b8879f00-a84f-11ea-8ce3-1ef744aab2ac.png)


<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Changed the name of the old bard preset to Popstar and some minor changes to the starting items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
