### PR TITLE
Arrivals doors will now automatically close

### DIFF
--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -24,6 +24,7 @@
 /obj/machinery/door/unpowered/shuttle/open()
 	playsound(loc, soundsopen, 30, 1)
 	. = ..()
+	autoclose = TRUE
 
 /obj/machinery/door/unpowered/shuttle/close()
 	if(density)

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -20,11 +20,11 @@
 	var/soundsclosed = 'sound/machines/airlock_close.ogg'
 	icon = 'icons/turf/shuttle.dmi'
 	icon_state = "door1"
+	autoclose = TRUE
 
 /obj/machinery/door/unpowered/shuttle/open()
 	playsound(loc, soundsopen, 30, 1)
 	. = ..()
-	autoclose = TRUE
 
 /obj/machinery/door/unpowered/shuttle/close()
 	if(density)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Since the arrivals shuttle door isn't a airlock subtype the var autoclose is FALSE. This changes that specifically for the arrivals shuttle door, and makes it autoclose just like any other airlock.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: The arrivals shuttle airlocks will now autoclose
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
