### PR TITLE
Add build-push-action to repository for CI/CD

### DIFF
--- a/.github/workflows/docker_build_and_push.yml
+++ b/.github/workflows/docker_build_and_push.yml
@@ -8,8 +8,8 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     steps:
-      run: |
-        ls
+      - run: |
+          ls
   deploy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker_build_and_push.yml
+++ b/.github/workflows/docker_build_and_push.yml
@@ -1,0 +1,7 @@
+uses: docker/build-push-action@v1
+with:
+  username: ${{ secrets.DOCKER_USERNAME }}
+  password: ${{ secrets.DOCKER_PASSWORD }}
+  repository: scorpiostation/scorpio
+  tag_with_sha: true
+  tags: ${{ env.GITHUB_SHA }}

--- a/.github/workflows/docker_build_and_push.yml
+++ b/.github/workflows/docker_build_and_push.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
 jobs:
   testing:
-    - name: Teststep
+    runs-on: ubuntu-latest
+    steps:
       run: |
         ls
   deploy:

--- a/.github/workflows/docker_build_and_push.yml
+++ b/.github/workflows/docker_build_and_push.yml
@@ -5,6 +5,10 @@ on:
       - master
   pull_request:
 jobs:
+  testing:
+    - name: Teststep
+      run: |
+        ls
   deploy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker_build_and_push.yml
+++ b/.github/workflows/docker_build_and_push.yml
@@ -7,20 +7,12 @@ on:
   pull_request:
 
 jobs:
-  checkout:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-  display:
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          ls
-
   build_and_push:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+      - run: |
+          ls
       - uses: docker/build-push-action@v1.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker_build_and_push.yml
+++ b/.github/workflows/docker_build_and_push.yml
@@ -1,16 +1,24 @@
 name: 'Build and Push to Docker'
+
 on:
   push:
     branches:
       - master
   pull_request:
+
 jobs:
-  testing:
+  checkout:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+  display:
     runs-on: ubuntu-latest
     steps:
       - run: |
           ls
-  deploy:
+
+  build_and_push:
     runs-on: ubuntu-latest
     steps:
       - uses: docker/build-push-action@v1.1.0

--- a/.github/workflows/docker_build_and_push.yml
+++ b/.github/workflows/docker_build_and_push.yml
@@ -10,13 +10,13 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
     steps:
+      - name: Compute Docker Tag
+        run: echo ::set-env name=GITHUB_SHA_SHORT::$(echo $GITHUB_SHA | cut -c 1-12)
       - uses: actions/checkout@v2
-      - run: |
-          ls
       - uses: docker/build-push-action@v1.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: scorpiostation/scorpio
-          tag_with_sha: true
-          tags: ${{ env.GITHUB_SHA }}
+          tags: ${{ env.GITHUB_SHA_SHORT }}
+          add_git_labels: true

--- a/.github/workflows/docker_build_and_push.yml
+++ b/.github/workflows/docker_build_and_push.yml
@@ -1,7 +1,17 @@
-uses: docker/build-push-action@v1
-with:
-  username: ${{ secrets.DOCKER_USERNAME }}
-  password: ${{ secrets.DOCKER_PASSWORD }}
-  repository: scorpiostation/scorpio
-  tag_with_sha: true
-  tags: ${{ env.GITHUB_SHA }}
+name: 'Build and Push to Docker'
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/build-push-action@v1.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: scorpiostation/scorpio
+          tag_with_sha: true
+          tags: ${{ env.GITHUB_SHA }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ COPY --chown=ss13:ss13 . /scorpio
 COPY --chown=ss13:ss13 --from=byond_build /byond /byond
 COPY --chown=ss13:ss13 --from=byond_build /scorpio/paradise.dmb /scorpio/paradise.dmb
 COPY --chown=ss13:ss13 --from=byond_build /scorpio/paradise.rsc /scorpio/paradise.rsc
-COPY --chown=ss13:ss13 --from=rust-g:latest /rust-g/target/release/librust_g.so /scorpio/librust_g.so
+COPY --chown=ss13:ss13 --from=scorpiostation/rust-g:latest /rust-g/target/release/librust_g.so /scorpio/librust_g.so
 COPY --chown=ss13:ss13 --from=mariadb_library /usr/lib/i386-linux-gnu/libmariadb.so /scorpio/libmariadb.so
 
 #


### PR DESCRIPTION
## What Does This PR Do
Adds a GitHub Action ([build-push-action](https://github.com/marketplace/actions/build-and-push-docker-images)) to build our Dockerfile and push the image to our repository on Docker Hub.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Continuous Integration (CI) and Continuous Deployment (CD) are best practices in software development. Our software project benefits from having the image automatically built when chanegs are made and pushed to GitHub.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
