### PR TITLE
Fix command Admin Secrets Debug Make all areas powered

### DIFF
--- a/code/modules/events/apc_short.dm
+++ b/code/modules/events/apc_short.dm
@@ -65,7 +65,6 @@
 	// recharge the APCs
 	for(var/thing in GLOB.apcs)
 		var/obj/machinery/power/apc/C = thing
-		var/area/current_area = get_area(C)
 		if(!is_station_level(C.z))
 			continue
 		if(C.cell)

--- a/code/modules/events/apc_short.dm
+++ b/code/modules/events/apc_short.dm
@@ -59,7 +59,17 @@
 	log_and_message_admins("APC Short event shorted out [affected_apc_count] APCs.")
 
 /proc/power_restore(announce=TRUE)
-	power_restore_quick(announce)
+	if(announce)
+		GLOB.event_announcement.Announce("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')
+
+	// recharge the APCs
+	for(var/thing in GLOB.apcs)
+		var/obj/machinery/power/apc/C = thing
+		var/area/current_area = get_area(C)
+		if(!is_station_level(C.z))
+			continue
+		if(C.cell)
+			C.cell.charge = C.cell.maxcharge
 
 /proc/power_restore_quick(announce=TRUE)
 	if(announce)


### PR DESCRIPTION
## What Does This PR Do
Modifies `/proc/power_restore` to recharge APC cells instead of the SMES.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is useful for debugging and testing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
