### PR TITLE
Makes it so that using several ai uploads can't bypass the cooldown

### DIFF
--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -6,7 +6,6 @@
 	circuit = /obj/item/circuitboard/aiupload
 	var/mob/living/silicon/ai/current = null
 	var/opened = 0
-	var/next_upload = 0
 
 	light_color = LIGHT_COLOR_WHITE
 	light_range_on = 2
@@ -32,17 +31,21 @@
 			if(!current)//no AI selected
 				to_chat(user, "<span class='danger'>No AI selected. Please chose a target before proceeding with upload.")
 				return
-			if(next_upload > world.time)
-				to_chat(user, "<span class='danger'>No tensor processing units are available for neural network retraining. Please try again later.")
-				return
 			var/turf/T = get_turf(current)
 			if(!atoms_share_level(T, src))
 				to_chat(user, "<span class='danger'>Unable to establish a connection</span>: You're too far away from the target silicon!")
 				return
-			var/obj/item/aiModule/M = O
-			M.install(src)
-			next_upload = world.time + (60 SECONDS)
-			return
+			if(current.lawcooldown)
+				to_chat(user, "<span class='danger'>No tensor processing units are available for neural network retraining. Please try again later.")
+				return
+			else
+				var/obj/item/aiModule/M = O
+				M.install(src)
+				current.lawcooldown = TRUE
+				spawn(30 SECONDS)
+					current.uncooldown()
+				return
+
 		return ..()
 
 
@@ -83,8 +86,15 @@
 			if(!atoms_share_level(T, src))
 				to_chat(user, "<span class='danger'>Unable to establish a connection</span>: You're too far away from the target silicon!")
 				return
-			module.install(src)
-			return
+			if(current.lawcooldown)
+				to_chat(user, "<span class='danger'>No tensor processing units are available for neural network retraining. Please try again later.")
+				return
+			else
+				module.install(src)
+				current.lawcooldown = TRUE
+				spawn(30 SECONDS)
+					current.lawcooldown = FALSE
+				return
 		return ..()
 
 

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -1,6 +1,7 @@
 /mob/living/silicon
 	var/datum/ai_laws/laws = null
 	var/list/additional_law_channels = list("State" = "")
+	var/lawcooldown = FALSE
 
 /mob/living/silicon/proc/laws_sanity_check()
 	if(!src.laws)
@@ -140,3 +141,9 @@
 			continue
 		law_options += L
 	return pick(law_options)
+
+/mob/living/silicon/proc/uncooldown()
+	if(lawcooldown)
+		lawcooldown = FALSE
+	else
+		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Fixes #68

The cooldown is now stored on the AI itself and can therefore not be bypassed by having more than one upload.
This feature now also works on borg uploads.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Do not abuse game mechanics!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: borg uploads now also have a cooldown
tweak: The cooldown for uploading laws can no longer be bypassed by having more than one upload
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
