### PR TITLE
Gives mentors access to OOC while it is disabled

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -18,7 +18,7 @@ GLOBAL_VAR_INIT(admin_ooc_colour, "#b82e00")
 		to_chat(src, "<span class='danger'>Guests may not use OOC.</span>")
 		return
 
-	if(!check_rights(R_ADMIN|R_MOD, 0))
+	if(!check_rights(R_ADMIN|R_MOD|R_MENTOR, 0))
 		if(!config.ooc_allowed)
 			to_chat(src, "<span class='danger'>OOC is globally muted.</span>")
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This PR gives mentors the ability to speak in OOC after it has been disabled just like admins.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mentors are staff, and if they are trusted with seeing Ckeys in mhelps and having their own m-say, why would we worry about them breaking the rules of OOC?.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Mentors can now speak in OOC while it is disabled 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
