### PR TITLE
IPC balance changes

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.v41A.II.dmm
@@ -95840,10 +95840,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboard)
-"dgF" = (
-/obj/structure/reagent_dispensers/oil,
-/turf/simulated/floor/plasteel,
-/area/assembly/robotics)
 "dgG" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard,
@@ -126017,7 +126013,7 @@ cIx
 cJn
 cMj
 cLo
-dgF
+cLo
 cLo
 cQv
 cOX

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -46238,7 +46238,6 @@
 	dir = 2;
 	network = list("Research","SS13")
 	},
-/obj/structure/reagent_dispensers/oil,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteredcorner"

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -45,8 +45,6 @@
 	new /obj/item/clothing/suit/storage/labcoat(src)
 	new /obj/item/radio/headset/headset_sci(src)
 	new /obj/item/radio/headset/headset_sci(src)
-	new /obj/item/reagent_containers/food/drinks/oilcan(src)
-	new /obj/item/reagent_containers/food/drinks/oilcan(src)
 
 /obj/structure/closet/secure_closet/RD
 	name = "research director's locker"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -301,14 +301,13 @@
 	else if(nutrition >= NUTRITION_LEVEL_FAT)
 		msg += "[p_they(TRUE)] [p_are()] quite chubby.\n"
 
-	if(!isSynthetic() && blood_volume < BLOOD_VOLUME_SAFE)
+	if(blood_volume < BLOOD_VOLUME_SAFE)
 		msg += "[p_they(TRUE)] [p_have()] pale skin.\n"
 
 	if(bleedsuppress)
 		msg += "[p_they(TRUE)] [p_are()] bandaged with something.\n"
 	else if(bleed_rate)
-		var/bleed_message = !isSynthetic() ? "bleeding" : "leaking"
-		msg += "<B>[p_they(TRUE)] [p_are()] [bleed_message]!</B>\n"
+		msg += "<B>[p_they(TRUE)] [p_are()] bleeding!</B>\n"
 
 	if(reagents.has_reagent("teslium"))
 		msg += "[p_they(TRUE)] [p_are()] emitting a gentle blue glow!\n"

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -22,17 +22,13 @@
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."
 	death_sounds = list('sound/voice/borg_deathsound.ogg') //I've made this a list in the event we add more sounds for dead robots.
 
-	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_SCAN, NO_INTORGANS, NO_PAIN, NO_DNA, RADIMMUNE, VIRUSIMMUNE, NO_GERMS, NO_DECAY, NOTRANSSTING) //Computers that don't decay? What a lie!
+	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_BLOOD, NO_SCAN, NO_INTORGANS, NO_PAIN, NO_DNA, RADIMMUNE, VIRUSIMMUNE, NO_GERMS, NO_DECAY, NOTRANSSTING) //Computers that don't decay? What a lie!
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | HAS_HEAD_MARKINGS | HAS_HEAD_ACCESSORY | ALL_RPARTS
 	dietflags = 0		//IPCs can't eat, so no diet
 	taste_sensitivity = TASTE_SENSITIVITY_NO_TASTE
 	blood_color = "#1F181F"
 	flesh_color = "#AAAAAA"
-
-	blood_color = "#3C3C3C"
-	exotic_blood = "oil"
-	blood_damage_type = STAMINA
 
 	//Default styles for created mobs.
 	default_hair = "Blue IPC Screen"

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -312,8 +312,3 @@ proc/robot_healthscan(mob/user, mob/living/M)
 					to_chat(user, "[capitalize(O.name)]: <font color='red'>[O.damage]</font>")
 			if(!organ_found)
 				to_chat(user, "<span class='warning'>No prosthetics located.</span>")
-
-			if(H.isSynthetic())
-				to_chat(user, "<span class='notice'>Internal Fluid Level:[H.blood_volume]/[H.max_blood]</span>")
-				if(H.bleed_rate)
-					to_chat(user, "<span class='warning'>Warning:External component leak detected!</span>")

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -54,7 +54,7 @@
 			var/obj/item/organ/external/BP = X
 			var/brutedamage = BP.brute_dam
 
-			if(BP.is_robotic() && !isSynthetic())
+			if(BP.is_robotic())
 				continue
 
 			//We want an accurate reading of .len

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -236,35 +236,6 @@
 	status &= ~ORGAN_SPLINTED
 	status |= ORGAN_ROBOT
 
-/obj/item/organ/external/emp_act(severity)
-	if(!is_robotic() || emp_proof)
-		return
-	if(tough)
-		switch(severity)
-			if(1)
-				receive_damage(0, 5.5)
-				if(owner)
-					owner.Stun(10)
-			if(2)
-				receive_damage(0, 2.8)
-				if(owner)
-					owner.Stun(5)
-	else
-		switch(severity)
-			if(1)
-				receive_damage(0, 20)
-			if(2)
-				receive_damage(0, 7)
-
-/obj/item/organ/internal/emp_act(severity)
-	if(!is_robotic() || emp_proof)
-		return
-	switch(severity)
-		if(1)
-			receive_damage(20, 1)
-		if(2)
-			receive_damage(7, 1)
-
 /obj/item/organ/proc/shock_organ(intensity)
 	return
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -41,6 +41,9 @@
 	var/list/obj/item/organ/external/children
 	var/list/convertable_children = list()
 
+	// Does the organ take reduce damage from EMPs? IPC limbs get this by default
+	var/emp_resistant = FALSE
+
 	// Internal organs of this body part
 	var/list/internal_organs = list()
 
@@ -255,6 +258,34 @@
 		owner.updatehealth("limb heal damage")
 
 	return update_icon()
+
+/obj/item/organ/external/emp_act(severity)
+	if(!is_robotic() || emp_proof)
+		return
+	if(tough) // Augmented limbs
+		switch(severity)
+			if(1)
+				receive_damage(0, 5.5)
+				if(owner)
+					owner.Stun(10)
+			if(2)
+				receive_damage(0, 2.8)
+				if(owner)
+					owner.Stun(5)
+	else if(emp_resistant) // IPC limbs
+		switch(severity)
+			if(1)
+				// 5.28 (9 * 0.66 burn_mod) burn damage, 65.34 damage with 11 limbs.
+				receive_damage(0, 9)
+			if(2)
+				// 3.63 (5 * 0.66 burn_mod) burn damage, 39.93 damage with 11 limbs.
+				receive_damage(0, 5.5)
+	else // Basic prosthetic limbs
+		switch(severity)
+			if(1)
+				receive_damage(0, 20)
+			if(2)
+				receive_damage(0, 7)
 
 /*
 This function completely restores a damaged organ to perfect condition.

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -73,6 +73,15 @@
 		A.Remove(M)
 	return src
 
+/obj/item/organ/internal/emp_act(severity)
+	if(!is_robotic() || emp_proof)
+		return
+	switch(severity)
+		if(1)
+			receive_damage(20, 1)
+		if(2)
+			receive_damage(7, 1)
+
 /obj/item/organ/internal/replaced(var/mob/living/carbon/human/target)
     insert(target)
 

--- a/code/modules/surgery/organs/subtypes/machine.dm
+++ b/code/modules/surgery/organs/subtypes/machine.dm
@@ -5,6 +5,7 @@
 	min_broken_damage = 30
 	encased = null
 	status = ORGAN_ROBOT
+	emp_resistant = TRUE
 
 /obj/item/organ/external/head/ipc/New(mob/living/carbon/holder, datum/species/species_override = null)
 	..(holder, /datum/species/machine) // IPC heads need to be explicitly set to this since you can print them
@@ -13,6 +14,7 @@
 /obj/item/organ/external/chest/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	emp_resistant = TRUE
 
 /obj/item/organ/external/chest/ipc/New()
 	..()
@@ -21,6 +23,7 @@
 /obj/item/organ/external/groin/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	emp_resistant = TRUE
 
 /obj/item/organ/external/groin/ipc/New()
 	..()
@@ -29,6 +32,7 @@
 /obj/item/organ/external/arm/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	emp_resistant = TRUE
 
 /obj/item/organ/external/arm/ipc/New()
 	..()
@@ -37,6 +41,7 @@
 /obj/item/organ/external/arm/right/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	emp_resistant = TRUE
 
 /obj/item/organ/external/arm/right/ipc/New()
 	..()
@@ -45,6 +50,7 @@
 /obj/item/organ/external/leg/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	emp_resistant = TRUE
 
 /obj/item/organ/external/leg/ipc/New()
 	..()
@@ -53,6 +59,7 @@
 /obj/item/organ/external/leg/right/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	emp_resistant = TRUE
 
 /obj/item/organ/external/leg/right/ipc/New()
 	..()
@@ -61,6 +68,7 @@
 /obj/item/organ/external/foot/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	emp_resistant = TRUE
 
 /obj/item/organ/external/foot/ipc/New()
 	..()
@@ -69,6 +77,7 @@
 /obj/item/organ/external/foot/right/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	emp_resistant = TRUE
 
 /obj/item/organ/external/foot/right/ipc/New()
 	..()
@@ -77,6 +86,7 @@
 /obj/item/organ/external/hand/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	emp_resistant = TRUE
 
 /obj/item/organ/external/hand/ipc/New()
 	..()
@@ -85,6 +95,7 @@
 /obj/item/organ/external/hand/right/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	emp_resistant = TRUE
 
 /obj/item/organ/external/hand/right/ipc/New()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Based on https://github.com/ParadiseSS13/Paradise/pull/12628
Resolves https://github.com/ScorpioStation/ScorpioStation/issues/43

While reading this, do keep in mind that IPCs are still using old crit. This means they have only 100 usable HP before they fall over "unconscious" in crit and are helpless. Not to mention the 150% damage modifier for brute and burn which makes them die even quicker.

Compared to all other species, which are on new crit now, IPCs are extremely weak, and I feel it's time to give them something instead of just ignoring their situation. Please, before you respond with a kneejerk "No" on this, hear me out.

With that out of the way, let's get onto the changes:

    IPCs no longer have oil blood anymore:

Originally, I was going to make it so the lower oil they had, the slower they would move. However I could not find a good way to do this without using the stamina blood damage they currently use. But, if anyone has any suggestions on how to simply make low blood slow them without being too snowflake, I'd probably change it to that system.

    IPCs now take a flat amount of damage when they are affected by an EMP:

There are two types of EMP severity, level 1 and level 2. Severity 1s are always closer to the middle of EMPs. For example if you use an EMP implant, the first 4 tiles around the EMP are severity 1 and any more than that, are severity 2.

Severity 1 EMPs will do ~5.28 damage per limb for a total of ~65 damage if the IPC has 11 limbs. Severity 2 EMPs will do ~3.63 damage per limb for a total of ~40 damage if the IPC has 11 limbs.

This gives IPC's at least a chance to maybe fight back instead of taking 300 damage, losing all their limbs at once and turning into a nugget.

Keeping the damage modifier the same at 150%.

Well, these are my purposed balance changes, and they may not be perfect. However I really just wanted to make this PR to get the discussion going, because I think it's time we did something about IPC balance.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->


## Changelog
:cl:
tweak: The Robotics lab no longer has an oil tank
tweak: Robotics lockers no longer have oil cans in them
balance: IPCs no longer bleed oil
balance: Changes the EMP damage IPCs receieve. Severity 1 EMPs will do ~5.28 damage per limb for a total of ~65 damage if the IPC has 11 limbs. Severity 2 EMPs will do ~3.63 damage per limb for a total of ~40 damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
