### PR TITLE
Ghosts can spawn from diona nymph pods

### DIFF
--- a/code/modules/hydroponics/grown/nymph.dm
+++ b/code/modules/hydroponics/grown/nymph.dm
@@ -11,6 +11,44 @@
 	production = 1
 	yield = 1
 	reagents_add = list("plantmatter" = 0.1)
+	var/next_ping_at = 0
+
+// If the nymph pods are fully grown, allow ghosts that click on them to spawn as a nymph (decreases yield by 1 and kills the plant when yield reaches 0)
+/obj/item/seeds/nymph/attack_ghost(mob/dead/observer/O, obj/machinery/hydroponics/H)
+	if(!planted && !H)
+		if(isobserver(O) && (world.time >= next_ping_at))
+			next_ping_at = world.time + (20 SECONDS)
+			visible_message("<span class='notice'>[src] rustles gently, as if moved by a gentle breeze.</span>")
+		return
+	if(!H.harvest) 
+		to_chat(O, "[src] is not yet ready.")
+		return
+	if(H.dead)
+		to_chat(O, "[src] is dead!")
+		return
+	if(!(O in GLOB.respawnable_list))
+		to_chat(O, "You are not permitted to rejoin the round.")
+		return
+	else if(cannotPossess(O))
+		to_chat(O, "You have enabled antag HUD and are unable to re-enter the round.")
+		return
+	var/nymph_ask = alert("Become a Diona Nymph? You will not be able to be cloned!", "Diona Nymph Pod", "Yes", "No")
+	if(nymph_ask == "No" || !src || QDELETED(src))
+		return
+	if(H.myseed && yield > 0 && !H.dead)
+		adjust_yield(-1)
+		var/mob/living/simple_animal/diona/D = new /mob/living/simple_animal/diona(get_turf(H))
+		if(O.mind)
+			O.mind.transfer_to(D)
+			GLOB.non_respawnable_keys -= O.ckey
+			O.reenter_corpse()
+		visible_message(D, "A new diona nymph emerges from the pod, its antennae waving excitedly.")
+		if(yield <= 0)
+			visible_message("The seed pod withers away, now merely an empty husk.")
+			H.plantdies()
+		GLOB.respawnable_list += usr
+	else
+		to_chat(O, "The seed pod is no longer functional.")
 
 /obj/item/reagent_containers/food/snacks/grown/nymph_pod
 	seed = /obj/item/seeds/nymph

--- a/code/modules/hydroponics/grown/nymph.dm
+++ b/code/modules/hydroponics/grown/nymph.dm
@@ -15,7 +15,7 @@
 
 // If the nymph pods are fully grown, allow ghosts that click on them to spawn as a nymph (decreases yield by 1 and kills the plant when yield reaches 0)
 /obj/item/seeds/nymph/attack_ghost(mob/dead/observer/O, obj/machinery/hydroponics/H)
-	if(!planted)
+	if(!planted || !istype(O))
 		if(isobserver(O) && world.time >= next_ping_at)
 			next_ping_at = world.time + 20 SECONDS
 			visible_message("<span class='notice'>[src] rustles gently, as if moved by a gentle breeze.</span>")

--- a/code/modules/hydroponics/grown/nymph.dm
+++ b/code/modules/hydroponics/grown/nymph.dm
@@ -20,35 +20,35 @@
 			next_ping_at = world.time + (20 SECONDS)
 			visible_message("<span class='notice'>[src] rustles gently, as if moved by a gentle breeze.</span>")
 		return
-	if(!H.harvest) 
-		to_chat(O, "[src] is not yet ready.")
+	if(!H.harvest)
+		to_chat(O, "<span class='warning'>[src] is not yet ready.</span>")
 		return
 	if(H.dead)
-		to_chat(O, "[src] is dead!")
+		to_chat(O, "<span class='warning'>[src] is dead!</span>")
 		return
 	if(!(O in GLOB.respawnable_list))
-		to_chat(O, "You are not permitted to rejoin the round.")
+		to_chat(O, "<span class='warning'>You are not permitted to rejoin the round.</span>")
 		return
 	else if(cannotPossess(O))
-		to_chat(O, "You have enabled antag HUD and are unable to re-enter the round.")
+		to_chat(O, "<span class='warning'>You have enabled antag HUD and are unable to re-enter the round.</span>")
 		return
 	var/nymph_ask = alert("Become a Diona Nymph? You will not be able to be cloned!", "Diona Nymph Pod", "Yes", "No")
 	if(nymph_ask == "No" || !src || QDELETED(src))
 		return
-	if(H.myseed && yield > 0 && !H.dead)
+	if(H.myseed && yield && !H.dead)
 		adjust_yield(-1)
-		var/mob/living/simple_animal/diona/D = new /mob/living/simple_animal/diona(get_turf(H))
+		var/mob/living/simple_animal/diona/D = new(get_turf(H))
 		if(O.mind)
 			O.mind.transfer_to(D)
 			GLOB.non_respawnable_keys -= O.ckey
 			O.reenter_corpse()
-		visible_message(D, "A new diona nymph emerges from the pod, its antennae waving excitedly.")
-		if(yield <= 0)
-			visible_message("The seed pod withers away, now merely an empty husk.")
+		visible_message(D, "<span class='notice'>A new diona nymph emerges from the pod, its antennae waving excitedly.</span>")
+		if(!yield)
+			visible_message("<span class='notice'>The seed pod withers away, now merely an empty husk.</span>")
 			H.plantdies()
 		GLOB.respawnable_list += usr
 	else
-		to_chat(O, "The seed pod is no longer functional.")
+		to_chat(O, "<span class='warning'>The seed pod is no longer functional.</span>")
 
 /obj/item/reagent_containers/food/snacks/grown/nymph_pod
 	seed = /obj/item/seeds/nymph

--- a/code/modules/hydroponics/grown/nymph.dm
+++ b/code/modules/hydroponics/grown/nymph.dm
@@ -15,9 +15,9 @@
 
 // If the nymph pods are fully grown, allow ghosts that click on them to spawn as a nymph (decreases yield by 1 and kills the plant when yield reaches 0)
 /obj/item/seeds/nymph/attack_ghost(mob/dead/observer/O, obj/machinery/hydroponics/H)
-	if(!planted && !H)
-		if(isobserver(O) && (world.time >= next_ping_at))
-			next_ping_at = world.time + (20 SECONDS)
+	if(!planted)
+		if(isobserver(O) && world.time >= next_ping_at)
+			next_ping_at = world.time + 20 SECONDS
 			visible_message("<span class='notice'>[src] rustles gently, as if moved by a gentle breeze.</span>")
 		return
 	if(!H.harvest)
@@ -33,20 +33,21 @@
 		to_chat(O, "<span class='warning'>You have enabled antag HUD and are unable to re-enter the round.</span>")
 		return
 	var/nymph_ask = alert("Become a Diona Nymph? You will not be able to be cloned!", "Diona Nymph Pod", "Yes", "No")
-	if(nymph_ask == "No" || !src || QDELETED(src))
+	if(nymph_ask == "No" || QDELETED(src))
 		return
 	if(H.myseed && yield && !H.dead)
 		adjust_yield(-1)
 		var/mob/living/simple_animal/diona/D = new(get_turf(H))
 		if(O.mind)
-			O.mind.transfer_to(D)
 			GLOB.non_respawnable_keys -= O.ckey
+			GLOB.respawnable_list += O
+			O.mind.transfer_to(D)
 			O.reenter_corpse()
 		visible_message(D, "<span class='notice'>A new diona nymph emerges from the pod, its antennae waving excitedly.</span>")
 		if(!yield)
 			visible_message("<span class='notice'>The seed pod withers away, now merely an empty husk.</span>")
 			H.plantdies()
-		GLOB.respawnable_list += usr
+
 	else
 		to_chat(O, "<span class='warning'>The seed pod is no longer functional.</span>")
 

--- a/code/modules/hydroponics/grown/nymph.dm
+++ b/code/modules/hydroponics/grown/nymph.dm
@@ -15,8 +15,10 @@
 
 // If the nymph pods are fully grown, allow ghosts that click on them to spawn as a nymph (decreases yield by 1 and kills the plant when yield reaches 0)
 /obj/item/seeds/nymph/attack_ghost(mob/dead/observer/O, obj/machinery/hydroponics/H)
-	if(!planted || !istype(O))
-		if(isobserver(O) && world.time >= next_ping_at)
+	if(!istype(O))
+		return
+	if(!planted)
+		if(world.time >= next_ping_at)
 			next_ping_at = world.time + 20 SECONDS
 			visible_message("<span class='notice'>[src] rustles gently, as if moved by a gentle breeze.</span>")
 		return

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -275,6 +275,11 @@
 		return
 	return
 
+// GHOST INTERACTIONS - passes on a ghost click to the growing seed if present.
+/obj/machinery/hydroponics/attack_ghost(mob/dead/observer/O)
+	if(myseed)
+		myseed.attack_ghost(O, src)
+
 /obj/machinery/hydroponics/update_icon()
 	//Refreshes the icon and sets the luminosity
 	overlays.Cut()
@@ -469,8 +474,8 @@
 	harvest = 0
 	adjustPests(-10) // Pests die
 	if(!dead)
-		update_icon()
 		dead = 1
+		update_icon()
 	plant_hud_set_health()
 	plant_hud_set_status()
 
@@ -808,6 +813,7 @@
 			to_chat(user, "<span class='notice'>You plant [O].</span>")
 			dead = 0
 			myseed = O
+			myseed.planted = TRUE
 			age = 1
 			plant_health = myseed.endurance
 			plant_hud_set_health()

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -34,6 +34,7 @@
 
 	var/weed_rate = 1 //If the chance below passes, then this many weeds sprout during growth
 	var/weed_chance = 5 //Percentage chance per tray update to grow weeds
+	var/planted = FALSE // FALSE if it hasn't been planted, TRUE if it has.
 
 /obj/item/seeds/New(loc, nogenes = 0)
 	..()
@@ -108,8 +109,6 @@
 	adjust_weed_chance(rand(-wcmut, wcmut))
 	if(prob(traitmut))
 		add_random_traits(1, 1)
-
-
 
 /obj/item/seeds/bullet_act(obj/item/projectile/Proj) //Works with the Somatoray to modify plant variables.
 	if(istype(Proj, /obj/item/projectile/energy/florayield))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Based on https://github.com/ParadiseSS13/Paradise/pull/12424

Allows ghosts to spawn as diona nymphs from harvestable diona nymph pods by clicking on them. Doing so reduces the yield of the plant and will eventually kill it.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Slightly improves the spawning conditions of the diona nymph which should make it a little easier to get started.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Ghosts can now spawn as diona nymphs from nymph plants that are ready to harvest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
