### PR TITLE
Makes sure Ark Rep is command, and removes old NT rep being command

### DIFF
--- a/code/game/machinery/tcomms/nttc.dm
+++ b/code/game/machinery/tcomms/nttc.dm
@@ -33,7 +33,7 @@
 		"Blueshield" = "comradio",
 		"Captain" = "comradio",
 		"Head of Personnel" = "comradio",
-		"Nanotrasen Representative" = "comradio",
+		"Ark Soft Representative" = "comradio",
 		// Engineeering
 		"Atmospheric Technician" = "engradio",
 		"Chief Engineer" = "engradio",
@@ -114,7 +114,7 @@
 		"Mime" = "srvradio",
 	)
 	// Just command members
-	var/heads = list("Captain", "Head of Personnel", "Nanotrasen Representative", "Blueshield", "Chief Engineer", "Chief Medical Officer", "Research Director", "Head of Security", "Magistrate", "AI")
+	var/heads = list("Captain", "Head of Personnel", "Ark Soft Representative", "Blueshield", "Chief Engineer", "Chief Medical Officer", "Research Director", "Head of Security", "Magistrate", "AI")
 	// Just ERT
 	var/ert_jobs = list("Emergency Response Team Officer", "Emergency Response Team Engineer", "Emergency Response Team Medic", "Emergency Response Team Leader", "Emergency Response Team Member")
 	// Defined so code compiles and incase someone has a non-standard job


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Ark Rep will now count as command on the radio. Giving them bolder command, and the command outline thing when speaking.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Some Nanotrasen references being changed to Ark Soft. Mostly a fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Ark Soft Representative now counts as command, and replaces some old Nanotrasen Representative mentions from the code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
