### PR TITLE
Adjust Occupation Preferences window

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -601,7 +601,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 	metadata["[tweak]"] = new_metadata
 
 
-/datum/preferences/proc/SetChoices(mob/user, limit = 13, list/splitJobs = list("Civilian","Research Director","AI","Bartender"), width = 760, height = 790)
+/datum/preferences/proc/SetChoices(mob/user, limit = 15, list/splitJobs = list("Civilian","Research Director","AI","Bartender"), width = 780, height = 790)
 	if(!SSjobs)
 		return
 


### PR DESCRIPTION
## What Does This PR Do
Adjust the Occupation Preferences window so that Chaplain no longer falls off the right fold
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It looks better and doesn't hide the Chaplain in the scroll zone
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![occupation-preferences](https://user-images.githubusercontent.com/1283521/87258552-153b3280-c46a-11ea-88cd-0ee67b88881b.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Occupation Preferences window looks a little nicer now
/:cl:
