### PR TITLE
 Small grammar error fix in SMES announcement

### DIFF
--- a/code/modules/events/apc_short.dm
+++ b/code/modules/events/apc_short.dm
@@ -60,7 +60,7 @@
 
 /proc/power_restore(announce=TRUE)
 	if(announce)
-		GLOB.event_announcement.Announce("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')
+		GLOB.event_announcement.Announce("Power has been restored to the [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')
 
 	// recharge the APCs
 	for(var/thing in GLOB.apcs)


### PR DESCRIPTION
Added 'the' inbetween 'restored' and 'station name' , this should solve #49 

## What Does This PR Do
Fixes a tiny grammar error in "All SMESs on ARS Scorpius have been recharged. We apologize for the inconvenience." It adds the word 'the' between 'on' and 'ARS'
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a silly error.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![fix](https://user-images.githubusercontent.com/61982887/88463746-f1b0b880-ce69-11ea-8438-859ebda7e3eb.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
spellcheck: Fixes a tiny grammar error in "All SMESs on ARS Scorpius have been recharged. We apologize for the inconvenience." It adds the word 'the' between 'on' and 'ARS'
/:cl:

