### PR TITLE
Refactors gamemode setup

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -139,7 +139,7 @@ SUBSYSTEM_DEF(ticker)
 			current_state = GAME_STATE_PREGAME
 			Master.SetRunLevel(RUNLEVEL_LOBBY)
 			to_chat(world, "<B>Unable to start. </B> Not enough players. Reverting to pre-game lobby.")
-			return 0
+			return FALSE
 		M = pickweight(runnable_modes)
 		mode = M
 		if(mode)
@@ -153,7 +153,7 @@ SUBSYSTEM_DEF(ticker)
 		current_state = GAME_STATE_PREGAME
 		SSjobs.ResetOccupations()
 		Master.SetRunLevel(RUNLEVEL_LOBBY)
-		return 0
+		return FALSE
 
 	//Configure mode and assign player to special mode stuff
 	src.mode.pre_pre_setup()
@@ -166,7 +166,7 @@ SUBSYSTEM_DEF(ticker)
 		to_chat(world, "<B>Error setting up [GLOB.master_mode].</B> Reverting to pre-game lobby.")
 		SSjobs.ResetOccupations()
 		Master.SetRunLevel(RUNLEVEL_LOBBY)
-		return 0
+		return FALSE
 
 	if(hide_mode)
 		var/list/modes = new

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -122,15 +122,7 @@ SUBSYSTEM_DEF(ticker)
 	if(GLOB.master_mode=="secret")
 		hide_mode = 1
 	var/list/datum/game_mode/runnable_modes
-	var/list/datum/game_mode/raw_modes
 	if((GLOB.master_mode=="random") || (GLOB.master_mode=="secret"))
-		runnable_modes = config.get_runnable_modes()
-		raw_modes = runnable_modes.Copy()
-		if(runnable_modes.len==0)
-			current_state = GAME_STATE_PREGAME
-			Master.SetRunLevel(RUNLEVEL_LOBBY)
-			to_chat(world, "<B>Unable to choose playable game mode.</B> Reverting to pre-game lobby.")
-			return 0
 		if(GLOB.secret_force_mode != "secret")
 			var/datum/game_mode/M = config.pick_mode(GLOB.secret_force_mode)
 			if(M.can_start())
@@ -138,18 +130,19 @@ SUBSYSTEM_DEF(ticker)
 				SSjobs.ResetOccupations()
 			else
 				message_admins("<B>Unable to start secret [mode.name].</B> Not enough players, [mode.required_players] players needed. Reverting to normal secret rotation.")
-		while(!mode)
-			SSjobs.ResetOccupations()
-			if(runnable_modes)
-				var/datum/game_mode/M = pickweight(runnable_modes)
-				if(!M.can_start())
-					runnable_modes -= M
-				else
-					mode = M
-			else
-				to_chat(world, "<B>Unable to choose playable game mode.</B> Reverting to pre-game lobby.")
-				return FALSE
-		if(src.mode)
+		runnable_modes = config.get_runnable_modes()
+		var/datum/game_mode/M
+		for(M in runnable_modes)
+			if(!M.can_start())
+				runnable_modes -= M
+		if(runnable_modes.len==0)
+			current_state = GAME_STATE_PREGAME
+			Master.SetRunLevel(RUNLEVEL_LOBBY)
+			to_chat(world, "<B>Unable to start. </B> Not enough players. Reverting to pre-game lobby.")
+			return 0
+		M = pickweight(runnable_modes)
+		mode = M
+		if(mode)
 			var/mtype = mode.type
 			mode = new mtype
 	else
@@ -177,7 +170,7 @@ SUBSYSTEM_DEF(ticker)
 
 	if(hide_mode)
 		var/list/modes = new
-		for(var/datum/game_mode/M in raw_modes)
+		for(var/datum/game_mode/M in runnable_modes)
 			modes+=M.name
 		modes = sortList(modes)
 		to_chat(world, "<B>The current game mode is - Secret!</B>")

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -3,7 +3,7 @@
 	config_tag = "traitorchan"
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 10
+	required_players = 25
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
 	var/protected_species_changeling = list("Machine")

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -3,7 +3,7 @@
 	config_tag = "traitorchan"
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 25
+	required_players = 30
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
 	var/protected_species_changeling = list("Machine")

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -12,7 +12,7 @@
 	config_tag = "traitor"
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Ark Soft Representative", "Security Pod Pilot", "Magistrate", "Internal Affairs Agent", "Brig Physician", "Ark Soft Navy Officer", "Special Operations Officer", "Syndicate Officer")
-	required_players = 25
+	required_players = 20
 	required_enemies = 1
 	recommended_enemies = 4
 

--- a/code/game/gamemodes/vampire/traitor_vamp.dm
+++ b/code/game/gamemodes/vampire/traitor_vamp.dm
@@ -4,7 +4,7 @@
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Ark Soft Representative", "Security Pod Pilot", "Magistrate", "Chaplain", "Brig Physician", "Internal Affairs Agent", "Ark Soft Navy Officer", "Special Operations Officer")
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 10
+	required_players = 25
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
 	var/protected_species_vampire = list("Machine")

--- a/code/game/gamemodes/vampire/traitor_vamp.dm
+++ b/code/game/gamemodes/vampire/traitor_vamp.dm
@@ -4,7 +4,7 @@
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Ark Soft Representative", "Security Pod Pilot", "Magistrate", "Chaplain", "Brig Physician", "Internal Affairs Agent", "Ark Soft Navy Officer", "Special Operations Officer")
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 25
+	required_players = 30
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
 	var/protected_species_vampire = list("Machine")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Went to bed last night and couldn't sleep because of how disgustingly bad the original gamemode setup had been written. So I refactored it to make more sense.

Should now correctly list to players the potential gamemodes that can be picked from based on their player numbers (ignoring weight)
Also put a better error message if the countdown goes to 0 and there are NO readied players. No use starting a round with noone on.

Fixes #139 by clarifying why we're going back to lobby.

Also adjusts traitorvamp and traitorchan to require 30 minimum to start instead of 10.

Here are the new gamemode numbers:

Extended: 1 player minimum (otherwise keep resetting roundstart timer) -> fallback mode in secret.

Solo antags:
Traitor: 1 traitor per 20 crew - Requires 20 players to start
Traitorchang: 1 chang @ 30 crew + (1 traitor per 20 crew) - Requires 30 players to start
Traitorvamp: 1 vamp @ 30 crew + (1 traitor per 20 crew) - Requires 30 players to start
Chang: 1 chang per 25 crew - Requires 25 players to start
Vamp: 1 vamp per 25 crew - Requires 25 players to start
Blob: 1 core per 40 crew - Requires 40 players to start
Wizard: 1 wizard @ 40 crew, non-scalable for now - Requires 40 players to start
Shadowling: 2 slings @ 40 crew, non-scalable for now - Requires 40 players to start

Team/Conversion antags:
Cult: 2 cultists @ 40 crew, 3 @ 60, 4 @ 80 - Requires 40 players to start
Rev: 1 headrev @ 40 crew, 2 @ 60, 3 @ 80 - Requires 40 players to start
Nukeops: 3 ops @ 40 crew, 4 @ 60, 5 @ 80 - Requires 40 players to start

Meteor: 40 crew - Requires 40 players to start
Heist: Should not be in lineup
Devil: Should not be in lineup
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cleaner code, more expected behavior
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: refactored gamemode setup
fix: made traitorvamp and traitorchang 30 minimum to start.
tweak: tweaked balance numbers for traitors down to 1 per 20 crew.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
