### PR TITLE
Removes prisoner gear from normal brig lockers

### DIFF
--- a/_maps/map_files/emerald/emerald.dmm
+++ b/_maps/map_files/emerald/emerald.dmm
@@ -19329,7 +19329,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/storage/eva)
 "aRl" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/brig/perma,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "aRm" = (
@@ -32496,10 +32496,10 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/sorting)
 "bpT" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/brig/perma,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "bpU" = (
@@ -67816,12 +67816,12 @@
 	},
 /area/lawoffice)
 "czW" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/camera{
 	c_tag = "Prisoner Lockers";
 	dir = 2;
 	network = list("Prison","SS13")
 	},
+/obj/structure/closet/secure_closet/brig/perma,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "czX" = (
@@ -67932,11 +67932,11 @@
 	},
 /area/security/range)
 "cAg" = (
-/obj/structure/closet/secure_closet/brig,
 /obj/machinery/light{
 	dir = 1;
 	on = 1
 	},
+/obj/structure/closet/secure_closet/brig/perma,
 /turf/simulated/floor/plasteel,
 /area/security/prisonlockers)
 "cAh" = (

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -391,7 +391,10 @@
 	anchored = 1
 	var/id = null
 
-/obj/structure/closet/secure_closet/brig/New()
+/obj/structure/closet/secure_closet/brig/perma
+	name = "perma locker"
+
+/obj/structure/closet/secure_closet/brig/perma/New()
 	..()
 	new /obj/item/clothing/under/color/orange/prison(src)
 	new /obj/item/clothing/shoes/orange(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Normal brig shouldn't have prisoner clothing that encourages sec to break SOP. Made sure those clothes were only available in the perma lockers.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Making sure sec follows SOP is always good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed orange prisoner gear from normal brig lockers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
