### PR TITLE
Disable Random Events by Default

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -13,7 +13,7 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 
 /datum/event_container
 	var/severity = -1
-	var/delayed = 0
+	var/delayed = TRUE
 	var/delay_modifier = 1
 	var/next_event_time = 0
 	var/list/available_events


### PR DESCRIPTION
## What Does This PR Do
Modifies Events so that they begin paused (`delayed`). They will not fire during the game unless the admins explicitly enable them after roundstart.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
On low-population, events can be very disruptive.

This change disables random events by default at roundstart, but the admins can easily re-enable events with an admin command.

**To Re-Enable Events (Admin)**
Event (Tab) -> Event Panel Manager (Verb) -> Event Start (Section) -> Resume (Buttons)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Disabled random Events by default.
/:cl:
