### PR TITLE
Automatically turns off events below 15 players

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -21,10 +21,16 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 	var/datum/event_meta/next_event = null
 
 	var/last_world_time = 0
+	var/minimum_players = 15 // Minimum amount of crew for events to kick off
 
 /datum/event_container/process()
 	if(!next_event_time)
 		set_event_delay()
+
+	if(SSticker.mode.num_players_started() < minimum_players)
+		delayed = TRUE
+	else
+		delayed = FALSE
 
 	if(delayed)
 		next_event_time += (world.time - last_world_time)

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -27,11 +27,6 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 	if(!next_event_time)
 		set_event_delay()
 
-	if(SSticker.mode.num_players_started() < minimum_players)
-		delayed = TRUE
-	else
-		delayed = FALSE
-
 	if(delayed)
 		next_event_time += (world.time - last_world_time)
 	else if(world.time > next_event_time)
@@ -89,6 +84,10 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 	return picked_event
 
 /datum/event_container/proc/set_event_delay()
+	if(SSticker.mode.num_players_started() < minimum_players)
+		delayed = TRUE
+	else
+		delayed = FALSE
 	// If the next event time has not yet been set and we have a custom first time start
 	if(next_event_time == 0 && config.event_first_run[severity])
 		var/lower = config.event_first_run[severity]["lower"]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Alternative to #142 

Automatically disables events below 15 population, and turns it back on automatically at 15+
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Automatic lowpop management systems are superior to having admins manually turn on events every round at normal population numbers.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Automatically disable events below 15 players
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
