### PR TITLE
Adds Spam Filter to PDA Message Server

### DIFF
--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -1,5 +1,6 @@
 /datum/event/pda_spam
 	endWhen = 36000
+	var/spam_level = 0
 	var/last_spam_time = 0
 	var/obj/machinery/message_server/useMS
 
@@ -12,17 +13,27 @@
 		for(var/obj/machinery/message_server/MS in GLOB.message_servers)
 			if(MS.active)
 				useMS = MS
+				spam_level = MS.spam_filter_level
 				break
 
 /datum/event/pda_spam/tick()
-	if(world.time > last_spam_time + 3000)
-		//if there's no spam managed to get to receiver for five minutes, give up
+	// if no spam managed to get to a receiver for five minutes
+	if(world.time > last_spam_time + 5 MINUTES)
+		// then give up; stop the PDA spam event
 		kill()
 		return
 
+	// if we don't have an active messaging server
 	if(!useMS || !useMS.active)
+		// pick a new active messaging server
 		useMS = null
 		pick_message_server()
+
+	// if the messaging server had its spam filter upgraded
+	if(useMS && (useMS.spam_filter_level > spam_level))
+		// then stop the PDA spam event
+		kill()
+		return
 
 	if(useMS)
 		if(prob(5))

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -33,6 +33,12 @@
 		pick_message_server()
 
 	if(useMS)
+		// if our active messaging server acquired a spam filter
+		if(useMS.spam_filter)
+			// stop using the message server and try again next cycle
+			useMS = null
+			return
+
 		if(prob(5))
 			// /obj/machinery/message_server/proc/send_pda_message(var/recipient = "",var/sender = "",var/message = "")
 			var/list/viables = list()

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -1,6 +1,6 @@
 /datum/event/pda_spam
-	endWhen = 36000
-	var/spam_level = 0
+	endWhen = 1 HOURS
+
 	var/last_spam_time = 0
 	var/obj/machinery/message_server/useMS
 
@@ -11,14 +11,17 @@
 /datum/event/pda_spam/proc/pick_message_server()
 	if(GLOB.message_servers)
 		for(var/obj/machinery/message_server/MS in GLOB.message_servers)
+			// if this message server has a spam filter, skip it
+			if(MS.spam_filter)
+				continue
+			// if this message server is active, choose it
 			if(MS.active)
 				useMS = MS
-				spam_level = MS.spam_filter_level
 				break
 
 /datum/event/pda_spam/tick()
 	// if no spam managed to get to a receiver for five minutes
-	if(world.time > last_spam_time + 5 MINUTES)
+	if(world.time > (last_spam_time + 5 MINUTES))
 		// then give up; stop the PDA spam event
 		kill()
 		return
@@ -28,12 +31,6 @@
 		// pick a new active messaging server
 		useMS = null
 		pick_message_server()
-
-	// if the messaging server had its spam filter upgraded
-	if(useMS && (useMS.spam_filter_level > spam_level))
-		// then stop the PDA spam event
-		kill()
-		return
 
 	if(useMS)
 		if(prob(5))
@@ -91,11 +88,11 @@
 					"Due to my lack of agents I require an off-world financial account to immediately deposit the sum of 1 POINT FIVE MILLION credits.",\
 					"Greetings sir, I regretfully to inform you that as I lay dying here due to my lack ofheirs I have chosen you to recieve the full sum of my lifetime savings of 1.5 billion credits")
 				if(6)
-					sender = pick("Ark Soft Morale Divison","Feeling Lonely?","Bored?","www.wetskrell.ax")
-					message = pick("The Ark Soft Morale Division wishes to provide you with quality entertainment sites.",\
-					"WetSkrell.ax is a xenophillic website endorsed by AS for the use of male crewmembers among it's many stations and outposts.",\
-					"Wetskrell.ax only provides the higest quality of male entertaiment to Ark Soft Employees.",\
-					"Simply enter your Ark Soft Bank account system number and pin. With three easy steps this service could be yours!")
+					sender = pick("ArkSoft Morale Divison","Feeling Lonely?","Bored?","www.wetskrell.ax")
+					message = pick("The ArkSoft Morale Division wishes to provide you with quality entertainment sites.",\
+					"WetSkrell.ark is a xenophillic website endorsed by ArkSoft for the use of male crewmembers among it's many stations and outposts.",\
+					"Wetskrell.ark only provides the higest quality of male entertaiment to ArkSoft Employees.",\
+					"Simply enter your ArkSoft Bank account system number and pin. With three easy steps this service could be yours!")
 				if(7)
 					sender = pick("You have won free tickets!","Click here to claim your prize!","You are the 1000th vistor!","You are our lucky grand prize winner!")
 					message = pick("You have won tickets to the newest ACTION JAXSON MOVIE!",\
@@ -103,14 +100,15 @@
 					"You have won tickets to the newest romantic comedy 16 RULES OF LOVE!",\
 					"You have won tickets to the newest thriller THE CULT OF THE SLEEPING ONE!")
 
-			if(useMS.send_pda_message("[P.owner]", sender, message))	//Message been filtered by spam filter.
+			// if the message was not delivered, don't count it as sent
+			if(useMS.send_pda_message("[P.owner]", sender, message))
 				return
 
 			last_spam_time = world.time
 
-			if(prob(50)) //Give the AI an increased chance to intercept the message
+			if(prob(50)) // give the AI an increased chance to intercept the message
 				for(var/mob/living/silicon/ai/ai in GLOB.mob_list)
-					// Allows other AIs to intercept the message but the AI won't intercept their own message.
+					// allows other AIs to intercept the message but the AI won't intercept their own message
 					if(ai.aiPDA != P && ai.aiPDA != src)
 						ai.show_message("<i>Intercepted message from <b>[sender]</b></i> (Unknown / spam?) <i>to <b>[P:owner]</b>: [message]</i>")
 

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -58,6 +58,7 @@ GLOBAL_LIST_EMPTY(message_servers)
 	var/list/datum/data_rc_msg/rc_msgs = list()
 	var/active = 1
 	var/decryptkey = "password"
+	var/spam_filter_level = 1
 
 /obj/machinery/message_server/New()
 	GLOB.message_servers += src
@@ -113,11 +114,13 @@ GLOBAL_LIST_EMPTY(message_servers)
 			Console.set_light(2)
 
 /obj/machinery/message_server/attack_hand(user as mob)
-//	to_chat(user, "<span class='notice'>There seem to be some parts missing from this server. They should arrive on the station in a few days, give or take a few CentComm delays.</span>")
 	to_chat(user, "You toggle PDA message passing from [active ? "On" : "Off"] to [active ? "Off" : "On"]")
 	active = !active
+	// if we got turned back on, update the spam filter signatures
+	if(active)
+		to_chat(user, "A small display on the message server reads, 'Spam Filter Signatures Updated'")
+		spam_filter_level++
 	update_icon()
-
 	return
 
 /obj/machinery/message_server/update_icon()

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -58,7 +58,7 @@ GLOBAL_LIST_EMPTY(message_servers)
 	var/list/datum/data_rc_msg/rc_msgs = list()
 	var/active = 1
 	var/decryptkey = "password"
-	var/spam_filter_level = 1
+	var/spam_filter = FALSE
 
 /obj/machinery/message_server/New()
 	GLOB.message_servers += src
@@ -116,10 +116,10 @@ GLOBAL_LIST_EMPTY(message_servers)
 /obj/machinery/message_server/attack_hand(user as mob)
 	to_chat(user, "You toggle PDA message passing from [active ? "On" : "Off"] to [active ? "Off" : "On"]")
 	active = !active
-	// if we got turned back on, update the spam filter signatures
-	if(active)
-		to_chat(user, "A small display on the message server reads, 'Spam Filter Signatures Updated'")
-		spam_filter_level++
+	// if we got turned back on, and we don't have a spam filter
+	if(active && !spam_filter)
+		to_chat(user, "A small display on the message server reads, 'Spam Filter: Active'")
+		spam_filter = TRUE
 	update_icon()
 	return
 


### PR DESCRIPTION
## What Does This PR Do
tl;dr: PDA Spam can be countered by turning the PDA Message Server off and on again.

* Adds a Spam Filter flag to the PDA Message Server
* When the PDA Spam event starts, it can send spam to the PDA Message Server
* Turning the PDA Message Server off and on again causes the spam filter to activate.
* If the spam filter is activated, the event will stop sending messages to the message server, ending PDA spam.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Both the AI and RD can do something about the PDA Spam event. (This Fixes #146)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Power cycling PDA Message Server activates the Spam Filter.
/:cl:
