### PR TITLE
Bunch of painting bugfixes

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -438,6 +438,6 @@
 		alarmed.burglaralert(src)
 		visible_message("<span class='danger'>The burglar alarm goes off!</span>")
 		// Play the burglar alarm three times
-		for(var/i = 0, i < 4, i++)
+		for(var/i in 1 to 4)
 			playsound(src, 'sound/machines/burglar_alarm.ogg', 50, 0)
 			sleep(74) // 7.4 seconds long


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Fixes canvas -> easel offset
- Fixes being able to place more than one canvas on an easel
- Add max length to painting name and allows wider range of characters
- Fix removing a canvas from painting not resetting overlay
- Fix attaching new canvas to previously bugged painting
- Fix unscrewing/rescrewing a painting to wall (disables it until someone does art construction stuff)
- Paintings named by the canvases attached to them.
- Canvases are now alarmed when placed on paintings. Librarian's key disables alarm.
- Adds fingerprints to using key, placing canvas or using wirecutters

Fixes  #167
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Working paintings wheee
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Bunch of painting fixes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
