### PR TITLE
Final Painting/Displaycase Fixes

### DIFF
--- a/_maps/map_files/emerald/emerald.dmm
+++ b/_maps/map_files/emerald/emerald.dmm
@@ -5993,7 +5993,9 @@
 /turf/simulated/floor/wood,
 /area/library)
 "anA" = (
-/obj/structure/decorative_structures/metal/statue/tesla,
+/obj/structure/decorative_structures/metal/statue/tesla{
+	anchored = 1
+	},
 /turf/simulated/floor/wood,
 /area/library)
 "anB" = (
@@ -17971,6 +17973,7 @@
 	network = list("SS13")
 	},
 /obj/structure/sign/painting/library{
+	id = 3;
 	pixel_x = 30
 	},
 /turf/simulated/floor/wood,
@@ -32727,6 +32730,7 @@
 /obj/item/stack/tape_roll,
 /obj/item/pen/multi,
 /obj/structure/sign/painting/library_private{
+	id = 2;
 	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
@@ -36356,7 +36360,9 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/structure/displaycase/trophy,
+/obj/structure/displaycase/trophy{
+	id = 3
+	},
 /turf/simulated/floor/wood,
 /area/library)
 "bwU" = (
@@ -94610,6 +94616,7 @@
 /area/security/securehallway)
 "fpD" = (
 /obj/structure/sign/painting/library{
+	id = 4;
 	pixel_x = 30
 	},
 /turf/simulated/floor/wood,
@@ -94617,6 +94624,12 @@
 "gdD" = (
 /obj/structure/bookcase{
 	name = "bookcase (Other)"
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"hIo" = (
+/obj/structure/displaycase/trophy{
+	id = 2
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -94632,6 +94645,19 @@
 "myH" = (
 /obj/structure/bookcase{
 	name = "bookcase (Fiction)"
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"nPm" = (
+/obj/structure/sign/painting/library{
+	id = 2;
+	pixel_y = 30
+	},
+/turf/simulated/floor/wood,
+/area/library)
+"oMS" = (
+/obj/structure/displaycase/trophy{
+	id = 4
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -94673,7 +94699,9 @@
 /turf/simulated/floor/wood,
 /area/library)
 "xVl" = (
-/obj/structure/decorative_structures/metal/statue/metal_angel,
+/obj/structure/decorative_structures/metal/statue/metal_angel{
+	anchored = 1
+	},
 /turf/simulated/floor/wood,
 /area/library)
 
@@ -118950,7 +118978,7 @@ aJI
 aLS
 bjG
 aiM
-amK
+nPm
 bkO
 ajb
 ajb
@@ -119207,12 +119235,12 @@ aJI
 aAq
 bcP
 aiM
-xpp
+hIo
 bkO
 aOp
 bwT
 fpD
-xpp
+oMS
 bjl
 aaa
 arX

--- a/code/controllers/subsystem/persistance.dm
+++ b/code/controllers/subsystem/persistance.dm
@@ -78,24 +78,6 @@ SUBSYSTEM_DEF(persistence)
 
 	log_world("Loaded [saved_messages.len] engraved messages.")
 
-/datum/controller/subsystem/persistence/proc/LoadTrophies()
-	if(fexists("data/npc_saves/TrophyItems.sav")) //legacy compatability to convert old format to new
-		var/savefile/S = new /savefile("data/npc_saves/TrophyItems.sav")
-		var/saved_json
-		S >> saved_json
-		if(!saved_json)
-			return
-		saved_trophies = json_decode(saved_json)
-		fdel("data/npc_saves/TrophyItems.sav")
-	else
-		var/json_file = file("data/npc_saves/TrophyItems.json")
-		if(!fexists(json_file))
-			return
-		var/list/json = json_decode(file2text(json_file))
-		if(!json)
-			return
-		saved_trophies = json["data"]
-	SetUpTrophies(saved_trophies.Copy())
 
 /*
 /datum/controller/subsystem/persistence/proc/LoadRecentModes()
@@ -139,31 +121,42 @@ SUBSYSTEM_DEF(persistence)
 	antag_rep = json_decode(json)
 */
 
-/datum/controller/subsystem/persistence/proc/SetUpTrophies(list/trophy_items)
-	for(var/A in GLOB.trophy_cases)
-		var/obj/structure/displaycase/trophy/T = A
-		if (T.showpiece)
-			continue
-		T.added_roundstart = TRUE
+/datum/controller/subsystem/persistence/proc/LoadTrophies()
+	var/list/saved_trophies = list()
+	var/json_file = file("data/npc_saves/TrophyItems.json")
+	if(!fexists(json_file))
+		return
+	var/list/json = json_decode(file2text(json_file))
 
-		var/trophy_data = pick_n_take(trophy_items)
+	if(!json)
+		return
+	saved_trophies = json["data"]
 
-		if(!islist(trophy_data))
-			continue
-
-		var/list/chosen_trophy = trophy_data
-
-		if(!length(chosen_trophy)) //Malformed
+	for(var/item in saved_trophies)
+		if(!islist(item))
 			continue
 
-		var/path = text2path(chosen_trophy["path"]) //If the item no longer exist, this returns null
+		if(!length(item)) //Malformed
+			continue
+
+		var/path = text2path(item["path"]) //If the item no longer exist, this returns null
 		if(!path)
 			continue
 
-		T.showpiece = new /obj/item/showpiece_dummy(T, path)
-		T.trophy_message = chosen_trophy["message"]
-		T.placer_key = chosen_trophy["placer_key"]
-		T.update_icon()
+		var/id = item["id"]
+		for(var/A in GLOB.trophy_cases)
+			var/obj/structure/displaycase/trophy/T = A
+			if(T.id == id && !T.showpiece)
+				T.added_roundstart = TRUE
+				T.showpiece = new /obj/item/showpiece_dummy(T, path)
+				var/obj/item/showpiece_dummy/D = T.showpiece
+				D.originalpath = path
+				T.trophy_message = item["message"]
+				T.placer_key = item["placer_key"]
+				T.update_icon()
+
+	log_world("Loaded [saved_trophies.len] trophies.")
+
 
 /datum/controller/subsystem/persistence/proc/CollectData()
 	CollectChiselMessages()
@@ -265,30 +258,27 @@ SUBSYSTEM_DEF(persistence)
 
 
 /datum/controller/subsystem/persistence/proc/CollectTrophies()
+	for(var/A in GLOB.trophy_cases)
+		var/obj/structure/displaycase/trophy/T = A
+		if(T.showpiece)
+			var/list/data = list()
+			if(istype(T.showpiece,/obj/item/showpiece_dummy))
+				var/obj/item/showpiece_dummy/D = T.showpiece
+				data["path"] = D.originalpath
+			else
+				data["path"] = T.showpiece.type
+			data["message"] = T.trophy_message
+			data["placer_key"] = T.placer_key
+			data["id"] = T.id
+			saved_trophies += list(data)
+
 	var/json_file = file("data/npc_saves/TrophyItems.json")
+
+	log_world("Saved [saved_trophies.len] persistant display items.")
 	var/list/file_data = list()
-	file_data["data"] = remove_duplicate_trophies(saved_trophies)
+	file_data["data"] = saved_trophies
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))
-
-/datum/controller/subsystem/persistence/proc/remove_duplicate_trophies(list/trophies)
-	var/list/ukeys = list()
-	. = list()
-	for(var/trophy in trophies)
-		var/tkey = "[trophy["path"]]-[trophy["message"]]"
-		if(ukeys[tkey])
-			continue
-		else
-			. += list(trophy)
-			ukeys[tkey] = TRUE
-
-/datum/controller/subsystem/persistence/proc/SaveTrophy(obj/structure/displaycase/trophy/T)
-	if(!T.added_roundstart && T.showpiece)
-		var/list/data = list()
-		data["path"] = T.showpiece.type
-		data["message"] = T.trophy_message
-		data["placer_key"] = T.placer_key
-		saved_trophies += list(data)
 
 /*
 /datum/controller/subsystem/persistence/proc/CollectRoundtype()

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -20,6 +20,7 @@
 			var/obj/item/canvas/C = I
 			user.drop_item(C)
 			painting = C
+			C.easel = src
 			C.forceMove(get_turf(src))
 			C.layer = layer+0.1
 			C.pixel_x = initial(C.pixel_x)
@@ -58,6 +59,7 @@
 	var/author_ckey
 	var/icon_generated = FALSE
 	var/icon/generated_icon
+	var/obj/structure/easel/easel
 
 	// Painting overlay offset when framed
 	var/framed_offset_x = 11
@@ -75,6 +77,10 @@
 	for(var/x in 1 to width)
 		for(var/y in 1 to height)
 			grid[x][y] = canvas_color
+
+/obj/item/canvas/attack_hand(mob/user)
+	if(..() && easel)
+		easel.painting = null
 
 /obj/item/canvas/attack_self(mob/user)
 	. = ..()
@@ -280,6 +286,7 @@
 		canvas = null
 		update_icon()
 		update_overlays()
+		update_icon_state()
 		name = initial(name)
 		if(alert)
 			trigger_alarm()
@@ -298,7 +305,8 @@
 		to_chat(user,"<span class='notice'>You frame [canvas] and attach the anti-theft system.</span>")
 		update_icon()
 		update_overlays()
-		name = canvas.name
+		update_icon_state()
+		name = canvas.painting_name
 		alert = TRUE
 		add_fingerprint(user)
 		return TRUE
@@ -325,8 +333,7 @@
 		frame.pixel_y = canvas.framed_offset_y - 1
 		add_overlay(frame)
 	else
-		for(var/mutable_appearance/MA in overlays)
-			cut_overlay(MA)
+		cut_overlays()
 
 /obj/structure/sign/painting/proc/load_persistent()
 	if(!persistence_id)
@@ -356,7 +363,8 @@
 	new_canvas.painting_name = title
 	new_canvas.author_ckey = author
 	canvas = new_canvas
-	name = canvas.name
+	name = canvas.painting_name
+	alert = TRUE
 	update_icon()
 	update_overlays()
 	update_icon_state()

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -17,6 +17,7 @@
 	var/start_showpiece_type = null //add type for items on display
 	var/list/start_showpieces = list() //Takes sublists in the form of list("type" = /obj/item/bikehorn, "trophy_message" = "henk")
 	var/trophy_message = ""
+	var/id = 1
 
 /obj/structure/displaycase/Initialize(mapload)
 	. = ..()
@@ -265,11 +266,8 @@ GLOBAL_LIST_EMPTY(trophy_cases)
 
 	var/obj/item/key/displaycase/K = W
 	if(istype(K))
-		if(added_roundstart)
-			is_locked = !is_locked
-			to_chat(user, "<span class='notice'>You [!is_locked ? "un" : ""]lock the case.</span>")
-		else
-			to_chat(user, "<span class='warning'>The lock is stuck shut!</span>")
+		is_locked = !is_locked
+		to_chat(user, "<span class='notice'>You [!is_locked ? "un" : ""]lock the case.</span>")
 		return
 
 	if(is_locked)
@@ -313,7 +311,6 @@ GLOBAL_LIST_EMPTY(trophy_cases)
 			else
 				to_chat(user, "<span class='warning'>You are too far to set the plaque's text!</span>")
 
-		SSpersistence.SaveTrophy(src)
 		return TRUE
 
 	else
@@ -336,6 +333,7 @@ GLOBAL_LIST_EMPTY(trophy_cases)
 
 /obj/item/showpiece_dummy
 	name = "Cheap replica"
+	var/originalpath
 
 /obj/item/showpiece_dummy/Initialize(mapload, path)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Fixes easels
- Add adminlogs when a painting is finalized so it records playername/ckey, jump, and painting name
- Add unique ID system to paintings and trophy cases so the same stuff shows up in the same order the next round
- Fix map to add unique ID to painting frames and trophy cases, and to lock down the 2 statues in library
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the persistant painting and display system work as intended
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fix easel, painting and trophy case saving
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
