### PR TITLE
Alarm and display case fixes

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -248,6 +248,7 @@
 	var/persistence_id
 	var/id = 1
 	var/alert = FALSE
+	var/obj/item/radio/Radio
 
 /obj/structure/sign/painting/Initialize(mapload, dir, building)
 	. = ..()
@@ -256,8 +257,13 @@
 		setDir(dir)
 	if(building)
 		set_pixel_offsets_from_dir(30, -30, 30, -30)
+	Radio = new /obj/item/radio(src)
+	Radio.listening = 0
+	Radio.config(list("Security" = 0))
+	Radio.follow_target = src
 
 /obj/structure/sign/painting/Destroy()
+	QDEL_NULL(Radio)
 	. = ..()
 	SSpersistence.painting_frames -= src
 
@@ -367,6 +373,7 @@
 		new_canvas.finalized = TRUE
 		new_canvas.painting_name = title
 		new_canvas.author_ckey = author
+		new_canvas.update_overlays()
 		canvas = new_canvas
 		name = canvas.painting_name
 		alert = TRUE
@@ -423,6 +430,8 @@
 		var/area/alarmed = get_area(src)
 		alarmed.burglaralert(src)
 		visible_message("<span class='danger'>The burglar alarm goes off!</span>")
+		var/announcetext = "403 - Grand Theft recorded occuring in [alarmed.name]."
+		Radio.autosay(announcetext, name, "Security", list(z))
 		// Play the burglar alarm three times
 		for(var/i in 1 to 4)
 			playsound(src, 'sound/machines/burglar_alarm.ogg', 50, 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Display cases (including the Captain's) and paintings now have a radio which will send out a message to sec if their alarms are triggered.
- Display cases in the library now act like the Captain's display case, making them repairable, allowing you to remove the replica items saved from previous rounds, or to replace the current round's items.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Standardization is good, and with these changes it will pave the way for 'heist' antag objectives related to player-created content.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds radios to display case and painting alarms, warning sec.
tweak: Makes library display cases act like the captain's
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
