### PR TITLE
Create new landmark type diskspawn for NAD respawns

### DIFF
--- a/code/_globalvars/mapping.dm
+++ b/code/_globalvars/mapping.dm
@@ -21,29 +21,34 @@ GLOBAL_LIST(global_map) // This is the array of zlevels | list(list(1,5),list(4,
 	//3 - AI satellite
 	//5 - empty space
 
-GLOBAL_LIST_EMPTY(wizardstart)
-GLOBAL_LIST_EMPTY(newplayer_start)
+// landmark lists -- see code/game/objects/effects/landmarks.dm
+GLOBAL_LIST_EMPTY(aroomwarp)
+GLOBAL_LIST_EMPTY(blobstart)
+GLOBAL_LIST_EMPTY(carplist)           // list of all carp-spawn landmarks
+GLOBAL_LIST_EMPTY(diskspawn)          // NAD respawn landmarks
+GLOBAL_LIST_EMPTY(emergencyresponseteamspawn)
+GLOBAL_LIST_EMPTY(ertdirector)
 GLOBAL_LIST_EMPTY(latejoin)
-GLOBAL_LIST_EMPTY(latejoin_gateway)
 GLOBAL_LIST_EMPTY(latejoin_cryo)
 GLOBAL_LIST_EMPTY(latejoin_cyborg)
-GLOBAL_LIST_EMPTY(prisonwarp)	//prisoners go to these
-GLOBAL_LIST_EMPTY(xeno_spawn)//Aliens spawn at these.
-GLOBAL_LIST_EMPTY(ertdirector)
-GLOBAL_LIST_EMPTY(emergencyresponseteamspawn)
+GLOBAL_LIST_EMPTY(latejoin_gateway)
+GLOBAL_LIST_EMPTY(newplayer_start)
+GLOBAL_LIST_EMPTY(ninjastart)
+GLOBAL_LIST_EMPTY(prisonsecuritywarp) // prison security goes to these
+GLOBAL_LIST_EMPTY(prisonwarp)         // prisoners go to these
+GLOBAL_LIST_EMPTY(raider_spawn)
+GLOBAL_LIST_EMPTY(syndicateofficer)
 GLOBAL_LIST_EMPTY(tdome1)
 GLOBAL_LIST_EMPTY(tdome2)
+GLOBAL_LIST_EMPTY(tdomeadmin)
+GLOBAL_LIST_EMPTY(tdomeobserve)
+GLOBAL_LIST_EMPTY(wizardstart)
+GLOBAL_LIST_EMPTY(xeno_spawn) // aliens spawn at these.
+
+// player lists; admin prison, dodgeball mode, etc.
+GLOBAL_LIST_EMPTY(prisonwarped)	//list of players already warped
 GLOBAL_LIST_EMPTY(team_alpha)
 GLOBAL_LIST_EMPTY(team_bravo)
-GLOBAL_LIST_EMPTY(tdomeobserve)
-GLOBAL_LIST_EMPTY(tdomeadmin)
-GLOBAL_LIST_EMPTY(aroomwarp)
-GLOBAL_LIST_EMPTY(prisonsecuritywarp)	//prison security goes to these
-GLOBAL_LIST_EMPTY(prisonwarped)	//list of players already warped
-GLOBAL_LIST_EMPTY(blobstart)
-GLOBAL_LIST_EMPTY(ninjastart)
-GLOBAL_LIST_EMPTY(carplist) //list of all carp-spawn landmarks
-GLOBAL_LIST_EMPTY(syndicateofficer)
 
 //away missions
 GLOBAL_LIST_EMPTY(awaydestinations)	//a list of landmarks that the warpgate can take you to

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -1,8 +1,7 @@
 /*
 VOX HEIST ROUNDTYPE
 */
-GLOBAL_LIST_EMPTY(raider_spawn)
-GLOBAL_LIST_EMPTY(cortical_stacks) //Stacks for 'leave nobody behind' objective. Clumsy, rewrite sometime.
+GLOBAL_LIST_EMPTY(cortical_stacks) // Stacks for 'leave nobody behind' objective. Clumsy, rewrite sometime.
 
 /datum/game_mode/
 	var/list/datum/mind/raiders = list()  //Antags.

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -455,15 +455,17 @@ GLOBAL_VAR(bomb_set)
 		STOP_PROCESSING(SSobj, src)
 		return ..()
 
-	if(GLOB.blobstart.len > 0)
+	if(GLOB.diskspawn.len > 0)
 		GLOB.poi_list.Remove(src)
-		var/obj/item/disk/nuclear/NEWDISK = new(pick(GLOB.blobstart))
+		var/obj/item/disk/nuclear/NEWDISK = new(pick(GLOB.diskspawn))
 		transfer_fingerprints_to(NEWDISK)
 		message_admins("[src] has been destroyed at ([diskturf.x], [diskturf.y], [diskturf.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[diskturf.x];Y=[diskturf.y];Z=[diskturf.z]'>JMP</a>). Moving it to ([NEWDISK.x], [NEWDISK.y], [NEWDISK.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[NEWDISK.x];Y=[NEWDISK.y];Z=[NEWDISK.z]'>JMP</a>).")
 		log_game("[src] has been destroyed in ([diskturf.x], [diskturf.y], [diskturf.z]). Moving it to ([NEWDISK.x], [NEWDISK.y], [NEWDISK.z]).")
 		return QDEL_HINT_HARDDEL_NOW
 	else
-		error("[src] was supposed to be destroyed, but we were unable to locate a blobstart landmark to spawn a new one.")
+		log_and_message_admins("[src] was supposed to be destroyed, but we were unable to locate a diskspawn landmark to spawn a new one.")
+		error("[src] was supposed to be destroyed, but we were unable to locate a diskspawn landmark to spawn a new one.")
+
 	return QDEL_HINT_LETMELIVE // Cancel destruction unless forced.
 
 #undef NUKE_INTACT

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -12,20 +12,25 @@
 	invisibility = 101
 
 	switch(name)			//some of these are probably obsolete
-		if("start")
-			GLOB.newplayer_start += loc
+		if("aroomwarp")
+			GLOB.aroomwarp += loc
+
+		if("blobstart")
+			GLOB.blobstart += loc
 			qdel(src)
 
-		if("wizard")
-			GLOB.wizardstart += loc
+		if("carpspawn")
+			GLOB.carplist += loc
+
+		if("diskspawn")
+			GLOB.diskspawn += loc
+
+		if("ERT Director")
+			GLOB.ertdirector += loc
 			qdel(src)
 
 		if("JoinLate")
 			GLOB.latejoin += loc
-			qdel(src)
-
-		if("JoinLateGateway")
-			GLOB.latejoin_gateway += loc
 			qdel(src)
 
 		if("JoinLateCryo")
@@ -36,12 +41,32 @@
 			GLOB.latejoin_cyborg += loc
 			qdel(src)
 
-		if("prisonwarp")
-			GLOB.prisonwarp += loc
+		if("JoinLateGateway")
+			GLOB.latejoin_gateway += loc
+			qdel(src)
+
+		if("ninjastart")
+			GLOB.ninjastart += loc
 			qdel(src)
 
 		if("prisonsecuritywarp")
 			GLOB.prisonsecuritywarp += loc
+			qdel(src)
+
+		if("prisonwarp")
+			GLOB.prisonwarp += loc
+			qdel(src)
+
+		if("Response Team")
+			GLOB.emergencyresponseteamspawn += loc
+			qdel(src)
+
+		if("start")
+			GLOB.newplayer_start += loc
+			qdel(src)
+
+		if("Syndicate Officer")
+			GLOB.syndicateofficer += loc
 			qdel(src)
 
 		if("tdome1")
@@ -56,37 +81,15 @@
 		if("tdomeobserve")
 			GLOB.tdomeobserve += loc
 
-		if("aroomwarp")
-			GLOB.aroomwarp += loc
+		if("voxstart")
+			GLOB.raider_spawn += loc
 
-		if("blobstart")
-			GLOB.blobstart += loc
+		if("wizard")
+			GLOB.wizardstart += loc
 			qdel(src)
 
 		if("xeno_spawn")
 			GLOB.xeno_spawn += loc
-			qdel(src)
-
-		if("ninjastart")
-			GLOB.ninjastart += loc
-			qdel(src)
-
-		if("carpspawn")
-			GLOB.carplist += loc
-
-		if("voxstart")
-			GLOB.raider_spawn += loc
-
-		if("ERT Director")
-			GLOB.ertdirector += loc
-			qdel(src)
-
-		if("Response Team")
-			GLOB.emergencyresponseteamspawn += loc
-			qdel(src)
-
-		if("Syndicate Officer")
-			GLOB.syndicateofficer += loc
 			qdel(src)
 
 	GLOB.landmarks_list += src


### PR DESCRIPTION
## What Does This PR Do
Creates a new `/obj/effect/landmark` type by name `diskspawn` that is used for Nuclear Authentication Disk (NAD) respawns should the disk be destroyed and/or leave the station z-level.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Scorpio discovered a bug where if a map had no `blobstart` landmarks, the NAD would fail to be destroyed and spam the holder with messages (#121, #178). This PR creates an appropriately named landmark to take over this responsibility. Now the new `diskspawn` landmarks can be added to the EmeraldStation map.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Creates new diskspawn landmark for NAD respawn points
/:cl:
