### PR TITLE
Remove debug logging messages from Census subsystem

### DIFF
--- a/code/controllers/subsystem/census.dm
+++ b/code/controllers/subsystem/census.dm
@@ -51,8 +51,6 @@ SUBSYSTEM_DEF(census)
 	return ..()
 
 /datum/controller/subsystem/census/fire()
-	log_and_message_admins("DEBUG: [name] subsystem: Firing at [round(world.time/10)]s into the round")
-
 	// determine the current server population
 	var/next_pop = length(GLOB.clients)
 	var/list/notify_us = list()
@@ -97,5 +95,4 @@ SUBSYSTEM_DEF(census)
 	var/body = json_encode(body_obj)
 
 	// call the webhook async, because this is a best effort notification
-	log_and_message_admins("DEBUG: [name] subsystem: Calling Discord webhook: [RUSTG_HTTP_METHOD_POST] http://discord.com/webhook [body] [headers]")
 	rustg_http_request_async(RUSTG_HTTP_METHOD_POST, webhook_url, body, headers)


### PR DESCRIPTION
## What Does This PR Do
Removes two lines from the Census subsystem that spam admins with debug logging messages.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admins who don't get spammed with debug messages are happy.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
