### PR TITLE
Fix Runechat Span Bug

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -619,4 +619,57 @@ proc/checkhtml(var/t)
 	text = replacetext(text, "<img src = ntlogo.png>",	"\[logo\]")
 	return text
 
-#define string2charlist(string) (splittext(string, regex("(\\x0A|.)")) - splittext(string, ""))
+
+/datum/html/split_holder
+	var/list/opening
+	var/inner_text
+	var/list/closing
+
+/datum/html/split_holder/New()
+	opening = list()
+	inner_text = ""
+	closing = list()
+
+/proc/split_html(raw_text="")
+	// gently borrowed and re-purposed from code/modules/pda/utilities.dm
+	// define a datum to hold our result
+	var/datum/html/split_holder/s = new()
+
+	// copy the raw_text to get started
+	var/text = copytext_char(raw_text, 1)
+
+	// search for tag brackets
+	var/tag_start = findtext_char(text, "<")
+	var/tag_stop = findtext_char(text, ">")
+
+	// until we run out of opening tags
+	while((tag_start != 0) && (tag_stop != 0))
+		// if the tag isn't at the beginning of the string
+		if(tag_start > 1)
+			// we've found our text, so copy it out
+			s.inner_text = copytext_char(text, 1, tag_start)
+			// and chop the text for the next round
+			text = copytext_char(text, tag_start)
+			break
+		// otherwise, we found an opening tag, so add it to the list
+		var/tag = copytext_char(text, tag_start, tag_stop)
+		s.opening.Add(tag)
+		// and chop the text for the next round
+		text = copytext_char(text, tag_stop+1)
+		// look for the next tag in what's left
+		tag_start = findtext(text, "<")
+		tag_stop = findtext(text, ">")
+
+	// until we run out of closing tags
+	while((tag_start != 0) && (tag_stop != 0))
+		// we found a closing tag, so add it to the list
+		var/tag = copytext_char(text, tag_start, tag_stop)
+		s.closing.Add(tag)
+		// and chop the text for the next round
+		text = copytext_char(text, tag_stop+1)
+		// look for the next tag in what's left
+		tag_start = findtext(text, "<")
+		tag_stop = findtext(text, ">")
+
+	// return the split html object to the caller
+	return s

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -652,7 +652,7 @@ proc/checkhtml(var/t)
 			text = copytext_char(text, tag_start)
 			break
 		// otherwise, we found an opening tag, so add it to the list
-		var/tag = copytext_char(text, tag_start, tag_stop)
+		var/tag = copytext_char(text, tag_start, tag_stop+1)
 		s.opening.Add(tag)
 		// and chop the text for the next round
 		text = copytext_char(text, tag_stop+1)
@@ -660,10 +660,14 @@ proc/checkhtml(var/t)
 		tag_start = findtext(text, "<")
 		tag_stop = findtext(text, ">")
 
+	// search for tag brackets
+	tag_start = findtext(text, "<")
+	tag_stop = findtext(text, ">")
+
 	// until we run out of closing tags
 	while((tag_start != 0) && (tag_stop != 0))
 		// we found a closing tag, so add it to the list
-		var/tag = copytext_char(text, tag_start, tag_stop)
+		var/tag = copytext_char(text, tag_start, tag_stop+1)
 		s.closing.Add(tag)
 		// and chop the text for the next round
 		text = copytext_char(text, tag_stop+1)

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -80,8 +80,10 @@
 
 	// Clip message
 	var/maxlen = owned_by.prefs.max_chat_length
-	if (length_char(text) > maxlen)
-		text = copytext_char(text, 1, maxlen + 1) + "..." // BYOND index moment
+	var/datum/html/split_holder/s = split_html(text)
+	if (length_char(s.inner_text) > maxlen)
+		var/chattext = copytext_char(s.inner_text, 1, maxlen + 1) + "..."
+		text = jointext(s.opening, "") + chattext + jointext(s.closing, "")
 
 	// Calculate target color if not already present
 //	if (!target.chat_color || target.chat_color_name != target.name)

--- a/code/game/dna/genes/disabilities.dm
+++ b/code/game/dna/genes/disabilities.dm
@@ -6,6 +6,8 @@
 // Gene is always activated.
 /////////////////////
 
+#define string2charlist(string) (splittext(string, regex("(\\x0A|.)")) - splittext(string, ""))
+
 /datum/dna/gene/disability
 	name = "DISABILITY"
 
@@ -260,3 +262,5 @@
 			garbled_message += C
 	message = garbled_message
 	return message
+
+#undef string2charlist


### PR DESCRIPTION
## What Does This PR Do
Adds a small HTML tag splitter to fix the Runechat bug where variants of `</span` appear after some Runechat messages.

I tracked down [the root cause of the problem](https://github.com/ScorpioStation/ScorpioStation/issues/105#issuecomment-667516552) about ~2.5 weeks ago (#105).

Fixes #105 
This fix unwraps the HTML tags from around the chat message. Runechat can now clip the message (and only the message) to the appropriate length. The message is then wrapped back up in the HTML tags. Since the closing tag is not being accidentally clipped, it will no longer appear in the maptext.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Variants of `</span` appearing after some Runechat messages is annoying and distracting.

Removing these makes the game experience smoother and more enjoyable for those using Runechat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed broken </span> tag appearing after some Runechat messages
/:cl:
