### PR TITLE
Clothing description replacement from NT to ARK

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -95,7 +95,7 @@
 
 /obj/item/clothing/suit/armor/secjacket
 	name = "security jacket"
-	desc = "A sturdy black jacket with reinforced fabric. Bears insignia of NT corporate security."
+	desc = "A sturdy black jacket with reinforced fabric. Bears insignia of Ark Soft corporate security."
 	icon_state = "secjacket_open"
 	item_state = "hos"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -210,7 +210,7 @@
 //Blueshield
 /obj/item/clothing/suit/storage/blueshield
 	name = "blueshield coat"
-	desc = "NT deluxe ripoff. You finally have your own coat."
+	desc = "Ark Soft deluxe ripoff. You finally have your own coat."
 	icon_state = "blueshieldcoat"
 	item_state = "blueshieldcoat"
 	blood_overlay_type = "coat"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -781,7 +781,7 @@
 
 /obj/item/clothing/suit/jacket/pilot
 	name = "security bomber jacket"
-	desc = "A stylish and worn-in armoured black bomber jacket emblazoned with the NT Security crest on the left breast. Looks rugged."
+	desc = "A stylish and worn-in armoured black bomber jacket emblazoned with the Ark Soft Security crest on the left breast. Looks rugged."
 	w_class = WEIGHT_CLASS_NORMAL
 	icon_state = "bombersec"
 	item_state = "bombersec"


### PR DESCRIPTION
## What Does This PR Do
Replaces three mentions of NT in departmental uniforms to Ark Soft
Fixes #202 

## Why It's Good For The Game
Ark Soft have their own sweatshops with cheap shirts, no need to buy Nanotrasen's overpriced products that catch on fire.

## Changelog
:cl:
tweak: Replaces mentions of NT in clothing to Ark Soft
/:cl:
