### PR TITLE
Fix and expand Discord arrivals announcement

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -187,6 +187,7 @@ SUBSYSTEM_DEF(ticker)
 	collect_minds()
 	equip_characters()
 	GLOB.data_core.manifest()
+	announce_manifest_to_discord()
 	current_state = GAME_STATE_PLAYING
 	Master.SetRunLevel(RUNLEVEL_GAME)
 
@@ -438,6 +439,22 @@ SUBSYSTEM_DEF(ticker)
 		for(var/mob/M in GLOB.player_list)
 			if(!isnewplayer(M))
 				to_chat(M, "Captainship not forced on anyone.")
+
+
+/datum/controller/subsystem/ticker/proc/announce_manifest_to_discord()
+	// build a list of everybody who is on the manifest
+	var/manifest = ""
+	for(var/datum/data/record/t in GLOB.data_core.general)
+		var/name = sanitize(t.fields["name"])
+		var/real_rank = t.fields["real_rank"]
+		manifest += "[name] ([real_rank])\n"
+	// if we have people on the list
+	if(length(manifest) > 0)
+		manifest = "The following brave souls have arrived on the station:\n" + manifest
+		// tell Discord who we've got
+		var/datum/discord/webhook/aac = new(config.discord_webhook_arrivals_url)
+		aac.post_message(manifest)
+
 
 /datum/controller/subsystem/ticker/proc/send_tip_of_the_round()
 	var/m

--- a/code/datums/discord/webhook.dm
+++ b/code/datums/discord/webhook.dm
@@ -1,4 +1,4 @@
-// discord.dm
+// webhook.dm
 // a datum to assist with Discord Webhook integrations
 //
 // see: https://support.discord.com/hc/en-us/articles/228383668

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -420,9 +420,10 @@
 					if(character.mind.role_alt_title)
 						rank = character.mind.role_alt_title
 					GLOB.global_announcer.autosay("[character.real_name],[rank ? " [rank]," : " visitor," ] [join_message ? join_message : "has arrived on the station"].", "Arrivals Announcement Computer")
-					// inform Discord
-					var/datum/discord/webhook/aac = new(config.discord_webhook_arrivals_url)
-					aac.post_message("[character.real_name], [rank ? " [rank]," : " visitor,"] has arrived on the station.")
+		// inform Discord
+		var/datum/discord/webhook/aac = new(config.discord_webhook_arrivals_url)
+		aac.post_message("[character.real_name],[rank ? " [rank]," : " visitor,"] has arrived on the station.")
+
 
 /mob/new_player/proc/AddEmploymentContract(mob/living/carbon/human/employee)
 	spawn(30)
@@ -447,9 +448,9 @@
 				if(character.mind.assigned_role != character.mind.special_role)
 					// can't use their name here, since cyborg namepicking is done post-spawn, so we'll just say "A new Cyborg has arrived"/"A new Android has arrived"/etc.
 					GLOB.global_announcer.autosay("A new[rank ? " [rank]" : " visitor" ] [join_message ? join_message : "has arrived on the station"].", "Arrivals Announcement Computer")
-					// inform Discord
-					var/datum/discord/webhook/aac = new(config.discord_webhook_arrivals_url)
-					aac.post_message("A new[rank ? " [rank]" : " visitor" ] has arrived on the station.")
+		// inform Discord
+		var/datum/discord/webhook/aac = new(config.discord_webhook_arrivals_url)
+		aac.post_message("A new[rank ? " [rank]" : " visitor" ] has arrived on the station.")
 
 /mob/new_player/proc/LateChoices()
 	var/mills = ROUND_TIME // 1/10 of a second, not real milliseconds but whatever


### PR DESCRIPTION
## What Does This PR Do
* Enables arrival announcements when an AI is present on the station (Bug Fix)
* Announces the round start manifest to Discord (New Announcement)
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This fixes a bug and helps people know who is actively playing the game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed Discord arrivals announcement so it works even when an AI is on the station
/:cl:
