### PR TITLE
PR- Small Vox

### DIFF
--- a/code/__DEFINES/genetics.dm
+++ b/code/__DEFINES/genetics.dm
@@ -149,3 +149,4 @@
 #define NO_DECAY		"no_decay"
 #define PIERCEIMMUNE	"pierce_immunity"
 #define NO_HUNGER		"no_hunger"
+#define SMALLVOX        "smallvox"

--- a/code/_globalvars/genetics.dm
+++ b/code/_globalvars/genetics.dm
@@ -30,6 +30,7 @@ GLOBAL_VAR_INIT(hallucinationblock, 0)
 GLOBAL_VAR_INIT(noprintsblock, 0)
 GLOBAL_VAR_INIT(shockimmunityblock, 0)
 GLOBAL_VAR_INIT(smallsizeblock, 0)
+GLOBAL_VAR_INIT(voxxysizeblock, 0)
 
 ///////////////////////////////
 // Goon Stuff

--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -100,6 +100,29 @@
 	..()
 	block = GLOB.shockimmunityblock
 
+/datum/dna/gene/basic/smallvox //This should not be acquirable in-game by players via Genetics as there is no assigned Structrural Enyzme for SmallVox
+	name= "SmallVox"
+	activation_messages = list("Now is smalls...")
+	deactivation_messages = list("Voxxy no longer feeling so small...Voxxy...talls?!")
+	instability = GENE_INSTABILITY_MINOR
+	mutation = SMALLVOX
+
+/datum/dna/gene/basic/smallvox/activate(mob/M, connected, flags)
+	..()
+	M.resize = 0.8
+	M.update_transform()
+	M_move_resist=M_FORCE_WEAK
+	
+/datum/dna/gene/basic/smallvox/deactivate(mob/M, connected, flags)
+	..()
+	M.resize = 1.25
+	M.update_transform()
+	M_move_resist = M_FORCE_NORMAL
+
+/datum/dna/gene/basic/smallvox/New()
+	..()
+	block = GLOB.voxxysizeblock
+
 /datum/dna/gene/basic/midget
 	name = "Midget"
 	activation_messages = list("Everything around you seems bigger now...")

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -23,7 +23,7 @@
 
 	eyes = "vox_eyes_s"
 
-	default_genes = list(DWARF)
+	default_genes = list(SMALLVOX)
 
 	species_traits = list(NO_SCAN, NO_GERMS, NO_DECAY, IS_WHITELISTED, NOTRANSSTING)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS //Species-fitted 'em all.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Replaces the usage of the "DWARF" gene in vox.dm with a new gene called "SMALLVOX". This new gene keeps the same resizing of the Vox sprite and reduces the Vox move resistance, but does not reduce the Vox push force.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A number of Vox mains from Paradise have told me that they want to try Scorpio but not being able to push crates and other items is turning them away. By separating the Vox resize and move resist from the push force (and DWARF gene), we can keep the resize and keep DWARF and hopefully get more players!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: New Gene: "SmallVox"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
