### PR TITLE
PR - Change how Vox Sizing Works

### DIFF
--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -23,8 +23,6 @@
 
 	eyes = "vox_eyes_s"
 
-	default_genes = list(DWARF)
-
 	species_traits = list(NO_SCAN, NO_GERMS, NO_DECAY, IS_WHITELISTED, NOTRANSSTING)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS //Species-fitted 'em all.
 	dietflags = DIET_OMNI
@@ -79,10 +77,6 @@
 
 /datum/species/vox/handle_dna(mob/living/carbon/human/H, remove)
 	..()
-	H.dna.SetSEState(GLOB.smallsizeblock, !remove, 1)
-	genemutcheck(H, GLOB.smallsizeblock, null, MUTCHK_FORCED)
-	H.dna.default_blocks.Add(GLOB.smallsizeblock)
-
 
 /datum/species/vox/handle_death(gibbed, mob/living/carbon/human/H)
 	H.stop_tail_wagging()
@@ -110,6 +104,16 @@
 /datum/species/vox/on_species_gain(mob/living/carbon/human/H)
 	..()
 	updatespeciescolor(H)
+	H.resize = 0.8
+	H.update_transform()
+	H.move_resist=MOVE_FORCE_WEAK
+	H.update_icons()
+
+/datum/species/vox/on_species_loss(mob/living/carbon/human/H)
+	..()
+	H.resize = 1.25
+	H.update_transform()
+	H.move_resist = MOVE_FORCE_NORMAL
 	H.update_icons()
 
 /datum/species/vox/updatespeciescolor(mob/living/carbon/human/H, owner_sensitive = 1) //Handling species-specific skin-tones for the Vox race.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
This separates the Vox sprite resize from the DWARF gene and allows Vox mobs to push. It retains their weak move resistance.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Several Vox mains from other servers have told me that they would consider Scorpio if not for the inability of Vox to push. While a unique gameplay mechanic, it has been frustrating to watch NPC monkeys push crates while your character cannot do the same. Hopefully this will make gameplay a little more balanced for Vox players.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: vox.dm to be self-reliant for resizing and WEAK move resistance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
