### PR TITLE
Adds Option to Synchronize Autotransfer Vote to Wall Clock

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -255,6 +255,8 @@
 	// Makes gamemodes respect player limits
 	var/enable_gamemode_player_limit = 0
 
+	var/autotransfer_wall_clock = FALSE // attempt to synchronize the autotransfer to the wall clock
+
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
 		var/datum/game_mode/M = T
@@ -446,6 +448,9 @@
 
 				if("vote_autotransfer_interval")
 					config.vote_autotransfer_interval = text2num(value)
+
+				if("autotransfer_wall_clock")
+					config.autotransfer_wall_clock = TRUE
 
 				if("default_no_vote")
 					config.vote_no_default = 1

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -294,6 +294,23 @@ SUBSYSTEM_DEF(ticker)
 	// Sets the auto shuttle vote to happen after the config duration
 	next_autotransfer = world.time + config.vote_autotransfer_initial
 
+	// if we're trying to synchronize the auto-transfer with the wall clock
+	if(config.autotransfer_wall_clock)
+		// 12 minutes = 1 minute voting + 5 minutes transit + 3 minutes boarding + 2 minutes escape + 1 minute EORG
+		var/time_from_vote_to_restart = 12 MINUTES
+		// deciseconds of wall clock time into our timeslot
+		var/delta_clock_to_current = world.timeofday % config.vote_autotransfer_initial
+		// deciseconds of wall clock time left in our timeslot
+		var/round_time_left = config.vote_autotransfer_initial - delta_clock_to_current
+		// deciseconds of wall clock time left after subtracting the length of round-end activity
+		round_time_left -= time_from_vote_to_restart
+		// if we're too close to the end of a wall clock timeslot
+		if(round_time_left < 0)
+			// just move it up to the next slot instead
+			round_time_left += config.vote_autotransfer_initial
+		// set the next autotransfer vote time to the calculated duration
+		next_autotransfer = world.time + round_time_left
+
 	for(var/mob/new_player/N in GLOB.mob_list)
 		if(N.client)
 			N.new_player_panel_proc()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -159,11 +159,14 @@ VOTE_DELAY 18000
 ## time period (deciseconds) which voting session will last (default 1 minute)
 VOTE_PERIOD 600
 
-## autovote initial delay (deciseconds) before first automatic transfer vote call (default 180 minutes)
+## autovote initial delay (deciseconds) before first automatic transfer vote call (default 120 minutes)
 VOTE_AUTOTRANSFER_INITIAL 72000
 
-##autovote delay (deciseconds) before sequential automatic transfer votes are called (default 60 minutes)
+## autovote delay (deciseconds) before sequential automatic transfer votes are called (default 30 minutes)
 VOTE_AUTOTRANSFER_INTERVAL 18000
+
+## uncomment to synchronize the automatic transfer vote to the wall clock
+#AUTOTRANSFER_WALL_CLOCK
 
 ## prevents dead players from voting or starting votes
 #NO_DEAD_VOTE


### PR DESCRIPTION
## What Does This PR Do
This adds a new configuration option `AUTOTRANSFER_WALL_CLOCK`.

When enabled in the configuration file, the initial autotransfer vote will be synchronized to occur 12 minutes before a multiple of the configured autotransfer period.

If you read that last sentence and had no clue what it meant: To try to synchronize round start with the wall clock (starting on the hour, XX:00) the timing of the initial autotransfer vote is calculated based on when (wall clock) the round starts, not a fixed duration.

**NOTE**: This has no effect on the vote mechanics or actual round length. In the general case, it means the first autotransfer vote may come sooner than usual. If the round continues or not, and how long it will actually last, is up to the voting players.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People can look at their clock and have a sense of when rounds are likely to be starting.
This also lays some of the foundation for the Scheduled Gamemodes part of Epoch 2.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new configuration option to synchronize autotransfer to the wall clock.
/:cl:
