### PR TITLE
Initiate crew transfer when the station is empty

### DIFF
--- a/code/controllers/subsystem/census.dm
+++ b/code/controllers/subsystem/census.dm
@@ -54,8 +54,9 @@ SUBSYSTEM_DEF(census)
 	// create the census_bot webhook for notifications
 	census_bot = new(json["webhook_url"])
 
-	// if we've got a round start role, announce round start with the current server population
-	if(round_start_role_id)
+	// if we've got a round start Discord role and there are people connected to play with
+	if((round_start_role_id) && (last_pop > 0))
+		// announce round start with the current server population
 		census_bot.post_message("<[round_start_role_id]> A new round is starting; [last_pop] players reconnected when the server restarted.")
 
 	// finish up successful initialization by returning whatever our parent returns

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -111,7 +111,10 @@ SUBSYSTEM_DEF(vote)
 				choices["Initiate Crew Transfer"] = round(choices["Initiate Crew Transfer"] * factor)
 				to_chat(world, "<font color='purple'>Crew Transfer Factor: [factor]</font>")
 				greatest_votes = max(choices["Initiate Crew Transfer"], choices["Continue The Round"])
-
+				// if there were no votes whatsoever, just initiate crew transfer
+				if(greatest_votes == 0)
+					choices["Initiate Crew Transfer"] = 1
+					greatest_votes = 1
 
 	//get all options with that many votes and return them in a list
 	. = list()


### PR DESCRIPTION
## What Does This PR Do
When there are no votes cast on the Crew Transfer vote, one vote to "Initiate Crew Transfer" is added to the ballot box.
It also modifies the Census Bot so that it does not alert when there are zero players connected.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When the station is empty, the round persists without ending. This allows the round to cycle. Accordingly, the Census Bot no longer alerts when zero players are connected, to avoid annoying people who have added that notification role in Discord.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Initiate Crew Transfer is now the default when no votes are cast.
/:cl:
