### PR TITLE
Cycle rounds when station is empty

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -256,6 +256,7 @@
 	var/enable_gamemode_player_limit = 0
 
 	var/autotransfer_wall_clock = FALSE // attempt to synchronize the autotransfer to the wall clock
+	var/census_bot_minimum = 2          // require this many connected players before census bot will announce
 
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
@@ -511,6 +512,9 @@
 
 				if("discordforumurl")
 					config.discordforumurl = value
+
+				if("census_bot_minimum")
+					config.census_bot_minimum = text2num(value)
 
 				if("discord_webhook_arrivals_url")
 					config.discord_webhook_arrivals_url = value

--- a/code/controllers/subsystem/census.dm
+++ b/code/controllers/subsystem/census.dm
@@ -54,8 +54,8 @@ SUBSYSTEM_DEF(census)
 	// create the census_bot webhook for notifications
 	census_bot = new(json["webhook_url"])
 
-	// if we've got a round start Discord role and there are people connected to play with
-	if((round_start_role_id) && (last_pop > 0))
+	// if we've got a round start Discord role and there are enough people connected to play with
+	if((round_start_role_id) && (last_pop >= config.census_bot_minimum))
 		// announce round start with the current server population
 		census_bot.post_message("<[round_start_role_id]> A new round is starting; [last_pop] players reconnected when the server restarted.")
 

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -67,7 +67,8 @@ SUBSYSTEM_DEF(vote)
 	var/list/sorted_choices = list()
 	var/sorted_highest
 	var/sorted_votes = -1
-	//get the highest number of votes, while also sorting the list
+
+	// get the highest number of votes, while also sorting the list
 	while(choices.len)
 		// This is a very inefficient sorting method, but that's okay
 		for(var/option in choices)
@@ -82,7 +83,8 @@ SUBSYSTEM_DEF(vote)
 		sorted_choices[sorted_highest] = choices[sorted_highest] || 0
 		choices -= sorted_highest
 	choices = sorted_choices
-	//default-vote for everyone who didn't vote
+
+	// default-vote for everyone who didn't vote
 	if(!config.vote_no_default && choices.len)
 		var/non_voters = (GLOB.clients.len - total_votes)
 		if(non_voters > 0)
@@ -111,12 +113,14 @@ SUBSYSTEM_DEF(vote)
 				choices["Initiate Crew Transfer"] = round(choices["Initiate Crew Transfer"] * factor)
 				to_chat(world, "<font color='purple'>Crew Transfer Factor: [factor]</font>")
 				greatest_votes = max(choices["Initiate Crew Transfer"], choices["Continue The Round"])
-				// if there were no votes whatsoever, just initiate crew transfer
-				if(greatest_votes == 0)
-					choices["Initiate Crew Transfer"] = 1
-					greatest_votes = 1
 
-	//get all options with that many votes and return them in a list
+	// if there were no votes whatsoever on a crew transfer vote
+	if((mode == "crew_transfer") && (greatest_votes == 0))
+		// just initiate the crew transfer
+		choices["Initiate Crew Transfer"] = 1
+		greatest_votes = 1
+
+	// get all options with that many votes and return them in a list
 	. = list()
 	if(greatest_votes)
 		for(var/option in choices)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -472,3 +472,6 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 
 ## If uncommented, all gamemodes will respect the number of required players. Defaults to no.
 #ENABLE_GAMEMODE_PLAYER_LIMIT
+
+## minimum number of players connected to the server before census bot will announce a new round (default 2)
+#CENSUS_BOT_MINIMUM 2


### PR DESCRIPTION
## What Does This PR Do
Adds a new configuration variable `CENSUS_BOT_MINIMUM` to avoid spamming new round notifications when the population is too low.
Fixes the default to `Initiate Crew Transfer` when no votes are cast during a crew transfer vote.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Abandoned Station gamemode works better when it can refresh.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed default Initiate Crew Transfer on crew transfer votes
/:cl:
