### PR TITLE
Nitrogen Tank Distribute Pressure Change

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -201,7 +201,7 @@ obj/item/tank/emergency_oxygen/double/empty/New()
 	name = "nitrogen tank"
 	desc = "A tank of nitrogen."
 	icon_state = "oxygen_fr"
-	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
 	sprite_sheets = list("Vox Armalis" = 'icons/mob/species/armalis/back.dmi') //Do it for Big Bird.
 
 /obj/item/tank/nitrogen/New()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Changes the default `distribute_pressure` for nitrogen tanks to `TANK_DEFAULT_RELEASE_PRESSURE` which is equal to 16, bringing Vox tanks to be on par with Plasmaman tanks.

Resolves #224 
## Why It's Good For The Game
Allows Vox tanks to last as long as Plasmaman tanks without having to go in and change the distribution pressure which somehow results in your character in-game actually getting a headache (literally, not figuratively). This is a bit of QoL balance since both species are classified as "Dangerous Species" (i.e. they require special breathing tanks) and many Vox players do not know about changing the distribution pressure on their tanks. With Scorpio rounds sometimes lasting over 2.5 hours, it's just a little nod to players.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaks default tank pressure for nitrogen tanks
fix: fixed a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
