### PR TITLE
Replaced deprecated ::set-env command in GitHub Actions

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Compute Docker Tag
-        run: echo ::set-env name=GITHUB_SHA_SHORT::$(echo $GITHUB_SHA | cut -c 1-12)
+        run: echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-12)" >> $GITHUB_ENV
       - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: scorpiostation/scorpio
-          tags: ${{ env.GITHUB_SHA_SHORT }}
+          tags: $GITHUB_SHA_SHORT
           add_git_labels: true
           push: false

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -15,6 +15,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: scorpiostation/scorpio
-          tags: $GITHUB_SHA_SHORT
+          tags: ${{ env.GITHUB_SHA_SHORT }}
           add_git_labels: true
           push: false

--- a/.github/workflows/docker_build_and_push.yml
+++ b/.github/workflows/docker_build_and_push.yml
@@ -17,6 +17,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: scorpiostation/scorpio
-          tags: $GITHUB_SHA_SHORT
+          tags: ${{ env.GITHUB_SHA_SHORT }}
           add_git_labels: true
           push: true

--- a/.github/workflows/docker_build_and_push.yml
+++ b/.github/workflows/docker_build_and_push.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Compute Docker Tag
-        run: echo ::set-env name=GITHUB_SHA_SHORT::$(echo $GITHUB_SHA | cut -c 1-12)
+        run: echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-12)" >> $GITHUB_ENV
       - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: scorpiostation/scorpio
-          tags: ${{ env.GITHUB_SHA_SHORT }}
+          tags: $GITHUB_SHA_SHORT
           add_git_labels: true
           push: true


### PR DESCRIPTION
## What Does This PR Do
Uses GitHub's Environment Files instead of the now deprecated ::set-env command to compute the docker tag from the commit sha:

> Warning: The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This change doesn't affect the game, only the CI tools for building and pushing to Docker.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
