### PR TITLE
Adds Abandoned Station game mode

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -51,3 +51,5 @@ GLOBAL_LIST_EMPTY(mob_spawners) 		    // All mob_spawn objects
 GLOBAL_LIST_EMPTY(explosive_walls)
 
 GLOBAL_LIST_EMPTY(engine_beacon_list)
+
+GLOBAL_LIST_INIT(closets, list())

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -118,6 +118,16 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/setup()
 	cultdat = setupcult()
+
+	// count up the number of ready players
+	var/ready_player_count = 0
+	for(var/mob/new_player/player in GLOB.player_list)
+		if((player.client) && (player.ready))
+			ready_player_count++
+	// if nobody is ready up, change the game mode to abandoned station
+	if(ready_player_count == 0)
+		GLOB.master_mode = "abandoned-station"
+
 	//Create and announce mode
 	if(GLOB.master_mode=="secret")
 		hide_mode = 1

--- a/code/game/gamemodes/abandoned/abandoned.dm
+++ b/code/game/gamemodes/abandoned/abandoned.dm
@@ -1,0 +1,115 @@
+// abandoned.dm
+// Copyright 2020 Patrick Meade
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+/datum/game_mode
+	var/mob/claimed_the_prize = null
+	var/obj/structure/closet/hiding_place = null
+	var/obj/item/stack/spacecash/c1000000/money = null
+
+/datum/game_mode/abandoned
+	name = "Abandoned Station"
+	config_tag = "abandoned-station"
+	required_players = 0
+	required_enemies = 0
+	recommended_enemies = 0
+	votable = 0
+
+/datum/game_mode/abandoned/announce()
+	to_chat(world, "<B>The current game mode is - Abandoned Station!</B>")
+	to_chat(world, "<B>Rumors of a vast sum of cash left behind have drawn you to the [station_name()].</B>")
+	to_chat(world, "Search the lockers on the station to find the prize, and return to the arrivals shuttle.")
+	to_chat(world, "<B>Beware!</B> Other treasure hunters are also after the prize and may be hostile!")
+	to_chat(world, "Other dangers may also lurk on the Abandoned Station...")
+
+/datum/game_mode/abandoned/can_start()
+	return ..()
+
+/datum/game_mode/abandoned/pre_setup()
+	// pick a random closet
+	hiding_place = pick(get_station_closets())
+	// create a stack of 1,000,000 credits
+	money = new()
+	// put the money in the closet
+	hiding_place.contents += money
+	// log and message the name and location of the closet containing the money
+	log_and_message_admins("[hiding_place] at ([hiding_place.x],[hiding_place.y],[hiding_place.z]) contains the cash!")
+	// tell the caller we successfully completed pre-setup
+	return TRUE
+
+/datum/game_mode/abandoned/post_setup()
+	return ..()
+
+/datum/game_mode/abandoned/proc/get_station_closets()
+	var/list/obj/structure/closet/L = list()
+	for(var/obj/structure/closet/i in GLOB.closets)
+		if(is_station_level(i.z))
+			L += i
+	return L
+
+/datum/game_mode/abandoned/declare_completion()
+	// announce if somebody won or not
+	if(claimed_the_prize)
+		to_chat(world, "[claimed_the_prize] has escaped the abandoned station with the cash!")
+	else
+		to_chat(world, "Nobody recovered the cash from the abandoned station!")
+	// allow our parent to complete processing
+	return ..()
+
+/datum/game_mode/proc/auto_declare_completion_abandoned()
+	return TRUE
+
+/datum/game_mode/abandoned/check_finished()
+	// for each player in the game
+	for(var/mob/P in GLOB.player_list)
+		// if the player is standing on the arrivals and escape shuttle
+		var/on_shuttle = FALSE
+		on_shuttle |= istype(get_area(P), /area/shuttle/arrival/station)
+		on_shuttle |= istype(get_area(P), /area/shuttle/escape)
+		if(on_shuttle)
+			// get all the items the player has
+			var/list/all_items = P.GetAllContents()
+			// for each item the player has
+			for(var/I in all_items)
+				// if it's the money
+				if(I == money)
+					// the player has won and the round is finished
+					claimed_the_prize = P
+					return TRUE
+	// otherwise, let's see if our parent thinks the round is finished
+	return ..()
+
+/datum/game_mode/abandoned/latespawn(mob/M)
+	..()
+	if(SSshuttle.emergency.mode >= SHUTTLE_ESCAPE)
+		return
+
+	// if this is an artifical intelligence
+	if(isAI(M))
+		var/datum/objective/abandoned/protectstation/O = new
+		M.mind.objectives += O
+		var/datum/antagonist/traitor/malf_ai = new
+		M.mind.add_antag_datum(malf_ai)
+	// otherwise this is a treasure hunter
+	else
+		var/datum/objective/abandoned/treasurehunt/O = new
+		M.mind.objectives += O
+
+	// tell the late-joiner about their objectives
+	M.mind.announce_objectives()
+
+//------------------------------------------------------------------------------
+// end of abandoned.dm

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -3,7 +3,7 @@ VOX HEIST ROUNDTYPE
 */
 GLOBAL_LIST_EMPTY(cortical_stacks) // Stacks for 'leave nobody behind' objective. Clumsy, rewrite sometime.
 
-/datum/game_mode/
+/datum/game_mode
 	var/list/datum/mind/raiders = list()  //Antags.
 	var/list/raid_objectives = list()     //Raid objectives
 
@@ -248,7 +248,7 @@ GLOBAL_LIST_EMPTY(cortical_stacks) // Stacks for 'leave nobody behind' objective
 
 	..()
 
-datum/game_mode/proc/auto_declare_completion_heist()
+/datum/game_mode/proc/auto_declare_completion_heist()
 	if(raiders.len)
 		var/check_return = 0
 		if(GAMEMODE_IS_HEIST)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -801,3 +801,13 @@ GLOBAL_LIST_INIT(potential_theft_objectives, (subtypesof(/datum/theft_objective)
 /datum/objective/wizchaos
 	explanation_text = "Wreak havoc upon the station as much you can. Send those wandless Ark Soft scum a message!"
 	completed = 1
+
+// abandoned-station
+
+/datum/objective/abandoned/protectstation
+	martyr_compatible = 0
+	explanation_text = "Terminate all looters who are searching the station for something to steal."
+
+/datum/objective/abandoned/treasurehunt
+	martyr_compatible = 0
+	explanation_text = "Recover the cash from the abandoned station by any means necessary."

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -23,6 +23,8 @@
 
 /obj/structure/closet/New()
 	..()
+	GLOB.closets += src
+	GLOB.closets = sortAtom(GLOB.closets)
 	spawn(1)
 		if(!opened)		// if closed, any item at the crate's loc is put in the contents
 			var/itemcount = 0
@@ -35,6 +37,7 @@
 
 // Fix for #383 - C4 deleting fridges with corpses
 /obj/structure/closet/Destroy()
+	GLOB.closets -= src
 	dump_contents()
 	return ..()
 

--- a/paradise.dme
+++ b/paradise.dme
@@ -493,6 +493,7 @@
 #include "code\game\gamemodes\scoreboard.dm"
 #include "code\game\gamemodes\setupgame.dm"
 #include "code\game\gamemodes\steal_items.dm"
+#include "code\game\gamemodes\abandoned\abandoned.dm"
 #include "code\game\gamemodes\autotraitor\autotraitor.dm"
 #include "code\game\gamemodes\blob\blob.dm"
 #include "code\game\gamemodes\blob\blob_finish.dm"


### PR DESCRIPTION
## What Does This PR Do
Creates a new gamemode Abandoned Station. This game mode starts automatically when 0 players are ready.

A bundle of cash ($1M) is hidden in a random locker on the station. Players join as treasure hunters looking for the cash, and must return to the arrivals shuttle or leave on the escape shuttle with the cash in order to win. An AI player joins as a dormant Malf-AI (now awake) that seeks to terminate looters on the station.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Provides a gamemode with an objective when the station is empty.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds Abandoned Station gamemode
/:cl:
