### PR TITLE
Obtain build dependencies without Docker Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,16 @@ This will take a while to download, but it provides an easier method for updatin
 First-time installation should be fairly straightforward.  
 First, you'll need to install [BYOND](https://secure.byond.com/download/).
 
-Second, you'll need to install [Docker Desktop](https://www.docker.com/get-started).
-(Ask on Discord if you need help.)
-
 This is a sourcecode-only release, so the next steps are to compile the server files.
 
-Third, there are some dependencies not included in the source tree. The pros
+Second, there are some dependencies not included in the source tree. The pros
 like to build these things for themselves, but we're going to cheat for now
 and just take the latest copies that somebody else built.
 
 Open up the folder where the code is kept, and run the script called
 `prepare-dev-windows.bat`
 
-Fourth, open `paradise.dme` by double-clicking it, open the Build menu, and
+Third, open `paradise.dme` by double-clicking it, open the Build menu, and
 click compile.  
 
 This'll take a little while, and if everything's done right,

--- a/prepare-dev-windows.bat
+++ b/prepare-dev-windows.bat
@@ -1,16 +1,3 @@
-REM === IMPORTANT: You need to install Docker Desktop to run this batch file! ===
-REM === See: https://www.docker.com/
-
-REM --- Download the latest ScorpioStation image from Docker Hub ---
-docker pull scorpiostation/scorpio:latest
-
-REM --- Create a ScorpioStation container to copy files from ---
-docker create --name delete_me scorpiostation/scorpio:latest
-
-REM --- Copy build resources from container to code folders ---
-docker cp delete_me:/scorpio/tgui/packages/tgui/public/tgui.bundle.css tgui/packages/tgui/public/tgui.bundle.css
-docker cp delete_me:/scorpio/tgui/packages/tgui/public/tgui.bundle.js tgui/packages/tgui/public/tgui.bundle.js
-docker cp delete_me:/scorpio/nano/images/Emerald_nanomap_z1.png nano/images/Emerald_nanomap_z1.png
-
-REM --- Remove the ScorpioStation container ---
-docker rm delete_me
+curl -k https://scorpiostation.com/tgui.bundle.css -o tgui/packages/tgui/public/tgui.bundle.css
+curl -k https://scorpiostation.com/tgui.bundle.js -o tgui/packages/tgui/public/tgui.bundle.js
+curl -k https://scorpiostation.com/Emerald_nanomap_z1.png -o nano/images/Emerald_nanomap_z1.png


### PR DESCRIPTION
## What Does This PR Do
This PR removes the instruction to download Docker Desktop on Windows.
The script to obtain build dependencies now uses `curl` commands to obtain and place the files.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Per @AffectedArc07 on #246 , Docker Desktop is just not an option for most people.
The updated script to obtain build dependencies is very simple.
It relies on a command that is [now standard on Windows](https://devblogs.microsoft.com/commandline/tar-and-curl-come-to-windows/) but [can be easily installed](https://curl.haxx.se/windows/) by those not running Windows 10.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
