### PR TITLE
Discord Webhook for Station Announcements

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -108,6 +108,7 @@
 	var/discordforumurl = "http://example.org"
 	var/discord_webhook_arrivals_url = null
 	var/discord_webhook_cryo_url = null
+	var/discord_webhook_announcement_url = null
 
 	var/overflow_server_url
 	var/forbid_singulo_possession = 0
@@ -515,6 +516,9 @@
 
 				if("census_bot_minimum")
 					config.census_bot_minimum = text2num(value)
+
+				if("discord_webhook_announcement_url")
+					config.discord_webhook_announcement_url = value
 
 				if("discord_webhook_arrivals_url")
 					config.discord_webhook_arrivals_url = value

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -67,8 +67,9 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 
 	var/formatted_message = Format_Message(message, message_title, message_announcer, from)
 	var/garbled_formatted_message = Format_Message(message_language.scramble(message), message_language.scramble(message_title), message_language.scramble(message_announcer), message_language.scramble(from))
+	var/discord_message = Format_Discord_Message(message, title, announcer, from)
 
-	Message(formatted_message, garbled_formatted_message, receivers, garbled_receivers)
+	Message(formatted_message, garbled_formatted_message, discord_message, receivers, garbled_receivers)
 
 	if(do_newscast)
 		NewsCast(message, message_title)
@@ -100,11 +101,25 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 
 	return list(receivers, garbled_receivers)
 
-/datum/announcement/proc/Message(message, garbled_message, receivers, garbled_receivers)
+/datum/announcement/proc/Message(message, garbled_message, discord_message, receivers, garbled_receivers)
 	for(var/mob/M in receivers)
 		to_chat(M, message)
 	for(var/mob/M in garbled_receivers)
 		to_chat(M, garbled_message)
+	var/datum/discord/webhook/sa = new(config.discord_webhook_announcement_url)
+	sa.post_message(discord_message)
+
+/datum/announcement/proc/Format_Discord_Message(message, message_title, message_announcer, from)
+	var/formatted_message = ""
+	if(from)
+		formatted_message += "__**[from]**__\n"
+	if(message_title)
+		formatted_message += "**[message_title]**\n"
+	if(message)
+		formatted_message += "[message]\n"
+	if(message_announcer)
+		formatted_message += "-[message_announcer]\n"
+	return formatted_message
 
 /datum/announcement/proc/Format_Message(message, message_title, message_announcer, from)
 	var/formatted_message

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -254,6 +254,9 @@ CHECK_RANDOMIZER
 ## Discord address (forum-based invite)
 # DISCORDFORUMURL http://example.org
 
+## Discord Webhook for Station Announcements
+# DISCORD_WEBHOOK_ANNOUNCEMENT_URL https://discord.com/api/webhooks/7444...
+
 ## Discord Webhook for Arrivals notification
 # DISCORD_WEBHOOK_ARRIVALS_URL https://discord.com/api/webhooks/7444...
 


### PR DESCRIPTION
## What Does This PR Do
Adds a Discord Webhook for Station Announcements.
Station announcements are sent to the webhook configured in `DISCORD_WEBHOOK_ANNOUNCEMENT_URL`
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is for fun. People can get a glimpse into the activity of a round. Yep, it's a bit IC'y OOC'y, but :shrug: ; it's still fun.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Discord Webhook for Station Announcements
/:cl:
