### PR TITLE
Fixes up title for announcements to Discord

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -67,7 +67,7 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 
 	var/formatted_message = Format_Message(message, message_title, message_announcer, from)
 	var/garbled_formatted_message = Format_Message(message_language.scramble(message), message_language.scramble(message_title), message_language.scramble(message_announcer), message_language.scramble(from))
-	var/discord_message = Format_Discord_Message(message, title, announcer, from)
+	var/discord_message = Format_Discord_Message(message, message_title, message_announcer, from)
 
 	Message(formatted_message, garbled_formatted_message, discord_message, receivers, garbled_receivers)
 


### PR DESCRIPTION
## What Does This PR Do
Fixes small bug in #255
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Fixed announcement title for announcements sent to Discord
/:cl:
