### PR TITLE
Enable Random Events on Any Population

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -21,7 +21,6 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 	var/datum/event_meta/next_event = null
 
 	var/last_world_time = 0
-	var/minimum_players = 15 // Minimum amount of crew for events to kick off
 
 /datum/event_container/process()
 	if(!next_event_time)
@@ -84,10 +83,6 @@ GLOBAL_LIST_EMPTY(event_last_fired)
 	return picked_event
 
 /datum/event_container/proc/set_event_delay()
-	if(SSticker.mode.num_players_started() < minimum_players)
-		delayed = TRUE
-	else
-		delayed = FALSE
 	// If the next event time has not yet been set and we have a custom first time start
 	if(next_event_time == 0 && config.event_first_run[severity])
 		var/lower = config.event_first_run[severity]["lower"]


### PR DESCRIPTION
## What Does This PR Do
This PR removes the change in #144 that disabled events when the population was below 15 people.

This reverts commit a3c533f5b0ac06b544d0dac9409a86b1ff2ddf3e, reversing
changes made to d3d1f6283d266af6e6e643babafdf1d6d25a0437.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A station where nothing happens is a pretty boring station.
If any specific events seem mismatched with gameplay, we can address those specific events.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Random events can now happen
/:cl:
