### PR TITLE
Fix NT Rep appearing as NOPE on the job preferences screen

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -621,7 +621,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 		return
 	for(var/datum/job/job in SSjobs.occupations)
 
-		if(job.admin_only)
+		if(job.admin_only || job.mentor_only)
 			continue
 
 		if(job.hidden_from_job_prefs)

--- a/code/upstream_shim.dm
+++ b/code/upstream_shim.dm
@@ -17,6 +17,7 @@
 
 // from: code/game/jobs/job/supervisor.dm
 /datum/job/nanotrasenrep
+    hidden_from_job_prefs = TRUE // NOPE ... this is a shim, not a real job
 
 // from: code/game/objects/items/weapons/AI_modules.dm
 /obj/item/aiModule/nanotrasen


### PR DESCRIPTION
## What Does This PR Do
Tells the NT Rep shim that it's not to appear on the Set Occupation Preferences screen.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nope, can't have NT Rep showing up on the jobs screen.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![](https://cdn.discordapp.com/attachments/728494917348753449/771151279337766922/unknown.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Fixed NOPE job on Set Occupation Preferences screen
/:cl:
