### PR TITLE
Removed duplicated Oxygen Canister

### DIFF
--- a/_maps/map_files/emerald/emerald.dmm
+++ b/_maps/map_files/emerald/emerald.dmm
@@ -78705,7 +78705,6 @@
 /area/hallway/primary/port/west)
 "cRP" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,


### PR DESCRIPTION
## What Does This PR Do
Removes a doubled up oxygen canister in toxins. Fixes #262 
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a small map bug
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed doubled up oxygen canister in Toxins Storage
/:cl:
