### PR TITLE
Fixes invisible marauder mechs.

### DIFF
--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -13,6 +13,7 @@
 	force = 40
 	wreckage = /obj/structure/mecha_wreckage/durand
 
+	cosmetics_enabled = TRUE
 	basecoat_icon = "durand-shell"
 	basecoat_colour = "#5b616e"
 	glow_icon = "durand-glow"
@@ -50,4 +51,3 @@
 	infra_luminosity = 8
 	force = 40
 	wreckage = /obj/structure/mecha_wreckage/durand/old
-	cosmetics_enabled = FALSE

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -18,6 +18,7 @@
 	step_energy_drain = 3
 	normal_step_energy_drain = 3
 
+	cosmetics_enabled = TRUE
 	basecoat_icon = "gygax-shell"
 	basecoat_colour = "#7f3617"
 	glow_icon = "gygax-glow"

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -17,6 +17,7 @@
 	starting_voice = /obj/item/mecha_modkit/voice/honk
 	var/squeak = 0
 
+	cosmetics_enabled = TRUE
 	basecoat_icon = "honker-shell"
 	basecoat_colour = "#880000"
 	glow_icon = "honker-glow"

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -19,6 +19,7 @@
 	force = 15
 	max_equip = 3
 
+	cosmetics_enabled = TRUE
 	basecoat_icon = "phazon-shell"
 	basecoat_colour = "#336699"
 	glow_icon = "phazon-glow"

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -102,7 +102,7 @@
 	var/base_icon_state
 
 	// Holding vars for cosmetic mods
-	var/cosmetics_enabled = TRUE // If false, will not show overlays nor open the paintgun UI.
+	var/cosmetics_enabled = FALSE // If false, will not show overlays nor open the paintgun UI.
 	var/basecoat_icon		// Base mech overlay (for colouring)
 	var/basecoat_colour = "#000000"
 
@@ -111,17 +111,17 @@
 
 	var/decal_icons = 'icons/mecha/mecha_decals.dmi'	// The file where the decal icons are stored. Seperated for neatness.
 	var/icon_decal_root	// Decals. Flame decals, anyone? Might have to make these as datums to hold colour info.
-	var/list/datum/mecha/mecha_decal/decals = list() 
+	var/list/datum/mecha/mecha_decal/decals = list()
 	var/list/datum/mecha/mecha_decal/default_decals = list() // Decals that come with the mech by default go here.
 
 	// Frontloads all the needed image processing to cut down on update checks.
 	var/icon/mech_icon_cache  // Contains the flattened new mech appearance after customization.
 	var/icon/glow_icon_cache  // Contains the glowy bits to be rendered on top.
 
-	// Some mechs with unreasonable numbers of decals can briefly halt the system while it processes. 
+	// Some mechs with unreasonable numbers of decals can briefly halt the system while it processes.
 	// This mode stops some of the more extraneous blends to speed up processing.
 	// This will reduce colour depth and may lead to layering issues if decals are not controlled.
-	var/fast_render_mode = FALSE 
+	var/fast_render_mode = FALSE
 
 	hud_possible = list (DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_MECH_HUD, DIAG_TRACK_HUD)
 
@@ -326,7 +326,7 @@
 	decals.Add(decal)
 	redraw_cache()
 	return TRUE
-	
+
 /obj/mecha/proc/strip_decal(var/datum/mecha/mecha_decal/decal)
 	if(decals)
 		decals.Remove(decal)
@@ -368,8 +368,8 @@
 	var/chosen_glitch = rand(1,5)
 	var/chosen_glitch_state = "glitch-[chosen_glitch]"
 	var/icon/glitch_icon = icon('icons/mecha/mecha_decals.dmi', chosen_glitch_state)
-	glitch_icon.Shift(NORTH,rand(-16, 16),TRUE) 
-	glitch_icon.Shift(EAST,rand(-16, 16),TRUE) 
+	glitch_icon.Shift(NORTH,rand(-16, 16),TRUE)
+	glitch_icon.Shift(EAST,rand(-16, 16),TRUE)
 	var/icon/glitch_mech = icon(mech_icon_cache, icon_state)
 	glitch_mech.AddAlphaMask(icon(glitch_icon))
 	var/icon/glitch_overlay = icon(glow_icon_cache, icon_state)
@@ -993,7 +993,7 @@
 		diag_hud_set_mechtracking()
 		return
 
-// Legacy support: adding paintkits disables the cosmetic modification system. 
+// Legacy support: adding paintkits disables the cosmetic modification system.
 // Still has some use for major visual overhauls.
 	else if(istype(W, /obj/item/overhaul_kit))
 		if(occupant)

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -13,6 +13,7 @@
 	normal_step_energy_drain = 6
 	var/builtin_hud_user = 0
 
+	cosmetics_enabled = TRUE
 	basecoat_icon = "odysseus-shell"
 	basecoat_colour = "#7b7b7b"
 	glow_icon = "odysseus-glow"

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -16,7 +16,7 @@
 	var/list/cargo = new
 	var/cargo_capacity = 15
 	var/hides = 0
-
+	cosmetics_enabled = TRUE
 	basecoat_icon = "ripley-shell"
 	basecoat_colour = "#8a7810"
 	glow_icon = "ripley-glow"


### PR DESCRIPTION

## What Does This PR Do
Fixes #270 - Invisible Mechs

## Changelog
:cl:
fix: seraph and marauder mechs no longer turn invisible when entered.
/:cl:
