### PR TITLE
Make station goal crates always orderable

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1789,6 +1789,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	name = "Empty Station Goal Crate"
 	cost = 10
 	special = TRUE
+	special_enabled = TRUE
 	containername = "empty station goal crate"
 	containertype = /obj/structure/closet/crate/engineering
 

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1796,6 +1796,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/misc/station_goal/bsa
 	name = "Bluespace Artillery Parts"
 	cost = 150
+	special_enabled = TRUE
 	contains = list(/obj/item/circuitboard/machine/bsa/front,
 					/obj/item/circuitboard/machine/bsa/middle,
 					/obj/item/circuitboard/machine/bsa/back,
@@ -1807,6 +1808,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/misc/station_goal/bluespace_tap
 	name = "Bluespace Harvester Parts"
 	cost = 150
+	special_enabled = TRUE
 	contains = list(
 					/obj/item/circuitboard/machine/bluespace_tap,
 					/obj/item/paper/bluespace_tap
@@ -1816,6 +1818,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/misc/station_goal/dna_vault
 	name = "DNA Vault Parts"
 	cost = 120
+	special_enabled = TRUE
 	contains = list(
 					/obj/item/circuitboard/machine/dna_vault
 					)
@@ -1824,6 +1827,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/misc/station_goal/dna_probes
 	name = "DNA Vault Samplers"
 	cost = 30
+	special_enabled = TRUE
 	contains = list(/obj/item/dna_probe,
 					/obj/item/dna_probe,
 					/obj/item/dna_probe,
@@ -1835,6 +1839,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/misc/station_goal/shield_sat
 	name = "Shield Generator Satellite"
 	cost = 30
+	special_enabled = TRUE
 	contains = list(
 					/obj/machinery/satellite/meteor_shield,
 					/obj/machinery/satellite/meteor_shield,
@@ -1845,6 +1850,7 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 /datum/supply_packs/misc/station_goal/shield_sat_control
 	name = "Shield System Control Board"
 	cost = 50
+	special_enabled = TRUE
 	contains = list(
 					/obj/item/circuitboard/computer/sat_control
 					)

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1789,7 +1789,6 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	name = "Empty Station Goal Crate"
 	cost = 10
 	special = TRUE
-	special_enabled = TRUE
 	containername = "empty station goal crate"
 	containertype = /obj/structure/closet/crate/engineering
 


### PR DESCRIPTION
## What Does This PR Do
Makes every station goal crate available for ordering at round start.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Per @TheMaveran on Discord...
```
TheMaveran Today at 8:59 AM
Here’s an idea to make engineering generally more enjoyable: Make all of the station goal projects orderable regardless of what the station goal actually is
Pretty much every engineer universally groans when it’s station shields
And a lot of people would just enjoy being able to do harvester
atmos pretty much has nothing to contribute to the station without the harvester as a goal
```

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: All station goal crates are available for ordering
/:cl:
