### PR TITLE
[READY] Tuulipommi's Barsign Fix - Remastered

### DIFF
--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -10,7 +10,8 @@
 	var/list/barsigns = list()
 	var/list/hiddensigns = list()
 	var/panel_open = FALSE
-	var/emagged = FALSE
+	var/emagged = TRUE
+	var/bolted = FALSE
 	var/prev_sign = ""
 	var/state = 0
 
@@ -56,22 +57,19 @@
 	return attack_hand(user)
 
 /obj/structure/sign/barsign/attack_hand(mob/user)
-	if(allowed(user))
+	if(panel_open)
 		if(broken)
 			to_chat(user, "<span class='danger'>The controls seem unresponsive.</span>")
 			return
 		else
-			if(panel_open)
-				pick_sign()
-				to_chat(user, "<span class='notice'>You set the barsign and close the maintenance panel.</span>")
-				panel_open = FALSE
-				return
-			else
-				to_chat(user, "<span class='info'>The maintenance panel is currently closed.</span>")
-				return
+			pick_sign()
+			to_chat(user, "<span class='notice'>You set the barsign and close the maintenance panel.</span>")
+			panel_open = FALSE
+			return
 	else
-		to_chat(user, "<span class='info'>Access denied.</span>")
+		to_chat(user, "<span class='info'>The maintenance panel is currently closed.</span>")
 		return
+
 
 /obj/structure/sign/barsign/attackby(var/obj/item/I, mob/user)
 	if(istype(I, /obj/item/stack/cable_coil) && panel_open)
@@ -92,13 +90,17 @@
 		return
 
 /obj/structure/sign/barsign/screwdriver_act(mob/user)
-	if(!panel_open)
-		to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
-		set_sign(new /datum/barsign/hiddensigns/signoff)
-		panel_open = TRUE
+	if(allowed(user))
+		if(!panel_open)
+			to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
+			set_sign(new /datum/barsign/hiddensigns/signoff)
+			panel_open = TRUE
+		else
+			to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
+			panel_open = FALSE
 	else
-		to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
-		panel_open = FALSE
+		to_chat(user, "<span class='info'>Access denied.</span>")
+		return
 
 /obj/structure/sign/barsign/proc/pick_sign()
 	var/list/signs = barsigns
@@ -382,6 +384,6 @@
 
 /datum/barsign/hiddensigns/signoff
 	name = "Bar Sign"
-	icon = "empty"
+	icon = "off"
 	desc = "This sign doesn't seem to be on."
 

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -7,28 +7,22 @@
 	max_integrity = 500
 	integrity_failure = 250
 	armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
-	var/list/barsigns=list()
-	var/list/hiddensigns
-	var/emagged = 0
-	var/state = 0
+	var/list/barsigns = list()
+	var/list/hiddensigns = list()
+	var/panel_open = FALSE
+	var/emagged =FALSE
 	var/prev_sign = ""
-	var/panel_open = 0
+	var/state = 0
 
 /obj/structure/sign/barsign/New()
 	..()
-
-
-//filling the barsigns list
+	//filling the barsigns list
 	for(var/bartype in subtypesof(/datum/barsign))
 		var/datum/barsign/signinfo = new bartype
 		if(!signinfo.hidden)
 			barsigns += signinfo
-
-
-//randomly assigning a sign
+	//randomly assigning a sign
 	set_sign(pick(barsigns))
-
-
 
 /obj/structure/sign/barsign/proc/set_sign(var/datum/barsign/sign)
 	if(!istype(sign))
@@ -56,12 +50,10 @@
 		if(BURN)
 			playsound(src.loc, 'sound/items/welder.ogg', 100, TRUE)
 
-/obj/structure/sign/barsign/attack_ai(mob/user as mob)
+/obj/structure/sign/barsign/attack_ai(mob/user)
 	return src.attack_hand(user)
 
-
-
-/obj/structure/sign/barsign/attack_hand(mob/user as mob)
+/obj/structure/sign/barsign/attack_hand(mob/user)
 	if(!src.allowed(user))
 		to_chat(user, "<span class = 'info'>Access denied.</span>")
 		return
@@ -70,25 +62,7 @@
 		return
 	pick_sign()
 
-
-
-
-/obj/structure/sign/barsign/attackby(var/obj/item/I, var/mob/user)
-	if( istype(I, /obj/item/screwdriver))
-		if(!panel_open)
-			to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
-			set_sign(new /datum/barsign/hiddensigns/signoff)
-			panel_open = 1
-		else
-			to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
-			if(!broken && !emagged)
-				set_sign(pick(barsigns))
-			else if(emagged)
-				set_sign(new /datum/barsign/hiddensigns/syndibarsign)
-			else
-				set_sign(new /datum/barsign/hiddensigns/empbarsign)
-			panel_open = 0
-
+/obj/structure/sign/barsign/attackby(var/obj/item/I, mob/user)
 	if(istype(I, /obj/item/stack/cable_coil) && panel_open)
 		var/obj/item/stack/cable_coil/C = I
 		if(emagged) //Emagged, not broken by EMP
@@ -97,23 +71,32 @@
 		else if(!broken)
 			to_chat(user, "<span class='warning'>This sign is functioning properly!</span>")
 			return
-
 		if(C.use(2))
 			to_chat(user, "<span class='notice'>You replace the burnt wiring.</span>")
-			broken = 0
+			broken = FALSE
 		else
 			to_chat(user, "<span class='warning'>You need at least two lengths of cable!</span>")
 	else
 		return ..()
 
-
+/obj/structure/sign/barsign/screwdriver_act(mob/user)
+	if(!panel_open)
+		to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
+		set_sign(new /datum/barsign/hiddensigns/signoff)
+		panel_open = TRUE
+	else
+		to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
+		if(!broken && !emagged)
+			set_sign(pick(barsigns))
+		else if(emagged)
+			set_sign(new /datum/barsign/hiddensigns/syndibarsign)
+		else
+			set_sign(new /datum/barsign/hiddensigns/empbarsign)
+		panel_open = FALSE
 
 /obj/structure/sign/barsign/emp_act(severity)
-    set_sign(new /datum/barsign/hiddensigns/empbarsign)
-    broken = 1
-
-
-
+	set_sign(new /datum/barsign/hiddensigns/empbarsign)
+	broken = TRUE
 
 /obj/structure/sign/barsign/emag_act(mob/user)
 	if(broken || emagged)
@@ -126,11 +109,8 @@
 	if(broken || emagged)
 		return
 	set_sign(new /datum/barsign/hiddensigns/syndibarsign)
-	emagged = 1
+	emagged = TRUE
 	req_access = list(ACCESS_SYNDICATE)
-
-
-
 
 /obj/structure/sign/barsign/proc/pick_sign()
 	var/picked_name = input("Available Signage", "Bar Sign") as null|anything in barsigns
@@ -141,9 +121,6 @@
 
 
 //Code below is to define useless variables for datums. It errors without these
-
-
-
 /datum/barsign
 	var/name = "Name"
 	var/icon = "Icon"
@@ -152,50 +129,40 @@
 
 
 //Anything below this is where all the specific signs are. If people want to add more signs, add them below.
-
-
-
 /datum/barsign/maltesefalcon
 	name = "Maltese Falcon"
 	icon = "maltesefalcon"
 	desc = "The Maltese Falcon, Space Bar and Grill."
-
 
 /datum/barsign/thebark
 	name = "The Bark"
 	icon = "thebark"
 	desc = "Ian's bar of choice."
 
-
 /datum/barsign/harmbaton
 	name = "The Harmbaton"
 	icon = "theharmbaton"
 	desc = "A great dining experience for both security members and assistants."
-
 
 /datum/barsign/thesingulo
 	name = "The Singulo"
 	icon = "thesingulo"
 	desc = "Where people go that'd rather not be called by their name."
 
-
 /datum/barsign/thedrunkcarp
 	name = "The Drunk Carp"
 	icon = "thedrunkcarp"
 	desc = "Don't drink and swim."
-
 
 /datum/barsign/scotchservinwill
 	name = "Scotch Servin Willy's"
 	icon = "scotchservinwill"
 	desc = "Willy sure moved up in the world from clown to bartender."
 
-
 /datum/barsign/officerbeersky
 	name = "Officer Beersky's"
 	icon = "officerbeersky"
 	desc = "Man eat a dong, these drinks are great."
-
 
 /datum/barsign/thecavern
 	name = "The Cavern"
@@ -390,12 +357,10 @@
 	desc = "Open since 2125, Not much has changed since then; the engineers still release the singulo and the damn miners still are more likely to cave your face in that deliver ores."
 
 /datum/barsign/hiddensigns
-	hidden = 1
+	hidden = TRUE
 
 
 //Hidden signs list below this point
-
-
 
 /datum/barsign/hiddensigns/empbarsign
 	name = "Haywire Barsign"

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -10,7 +10,7 @@
 	var/list/barsigns = list()
 	var/list/hiddensigns = list()
 	var/panel_open = FALSE
-	var/emagged =FALSE
+	var/emagged = FALSE
 	var/prev_sign = ""
 	var/state = 0
 

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -93,7 +93,7 @@
 	if(allowed(user))
 		if(!panel_open)
 			to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
-			set_sign(new /datum/barsign/hiddensigns/signoff)
+			set_sign(new /datum/barsign/signoff)
 			panel_open = TRUE
 		else
 			to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
@@ -105,18 +105,19 @@
 /obj/structure/sign/barsign/proc/pick_sign()
 	var/list/signs = barsigns
 	var/new_sign
-	if(!broken && !emagged)
-		new_sign = input("Available Signage: ", "Bar Sign", null) as null|anything in signs
-		set_sign(new_sign)
-	else if(!broken && emagged)
-		signs += hiddensigns
-		new_sign = input("Available Signage: ", "Bar Sign", null) as null|anything in signs
-		set_sign(new_sign)
+	if(!broken)
+		if(!emagged)
+			new_sign = input("Available Signage: ", "Bar Sign", null) as null|anything in signs
+			set_sign(new_sign)
+		else
+			signs += hiddensigns
+			new_sign = input("Available Signage: ", "Bar Sign", null) as null|anything in signs
+			set_sign(new_sign)
 	else
-		set_sign(new /datum/barsign/hiddensigns/empbarsign)
+		set_sign(new /datum/barsign/empbarsign)
 
 /obj/structure/sign/barsign/emp_act(severity)
-	set_sign(new /datum/barsign/hiddensigns/empbarsign)
+	set_sign(new /datum/barsign/empbarsign)
 	broken = TRUE
 
 /obj/structure/sign/barsign/emag_act(mob/user)
@@ -129,7 +130,7 @@
 /obj/structure/sign/barsign/proc/post_emag()
 	if(broken || emagged)
 		return
-	set_sign(new /datum/barsign/hiddensigns/syndibarsign)
+	set_sign(new /datum/barsign/syndibarsign)
 	emagged = TRUE
 	req_access = list(ACCESS_SYNDICATE)
 
@@ -138,7 +139,7 @@
 	var/name = "Name"
 	var/icon = "Icon"
 	var/desc = "desc"
-	var/hidden = 0
+	var/hidden = FALSE
 
 
 //Anything below this is where all the specific signs are. If people want to add more signs, add them below.
@@ -362,28 +363,22 @@
 	icon = "spaceasshole"
 	desc = "Open since 2125, Not much has changed since then; the engineers still release the singulo and the damn miners still are more likely to cave your face in that deliver ores."
 
-/datum/barsign/hiddensigns
-	hidden = TRUE
-
 
 //Hidden signs list below this point
-
-/datum/barsign/hiddensigns/empbarsign
+/datum/barsign/empbarsign
 	name = "Haywire Barsign"
 	icon = "empbarsign"
 	desc = "Something has gone very wrong."
+	hidden = TRUE
 
-
-
-/datum/barsign/hiddensigns/syndibarsign
+/datum/barsign/syndibarsign
 	name = "Syndi Cat Takeover"
 	icon = "syndibarsign"
 	desc = "Syndicate or die."
+	hidden = TRUE
 
-
-
-/datum/barsign/hiddensigns/signoff
+/datum/barsign/signoff
 	name = "Bar Sign"
 	icon = "off"
 	desc = "This sign doesn't seem to be on."
-
+	hidden = TRUE

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -18,7 +18,7 @@
 /obj/structure/sign/barsign/New()
 	..()
 	//filling the barsigns lists
-	for(var/bartype in subtypesof(/datum/barsign))
+	for(var/bartype in typesof(/datum/barsign))
 		var/datum/barsign/signinfo = new bartype
 		if(!signinfo.hidden)
 			barsigns += signinfo
@@ -58,13 +58,17 @@
 
 /obj/structure/sign/barsign/attack_hand(mob/user)
 	if(panel_open)
-		if(broken)
-			to_chat(user, "<span class='danger'>The controls seem unresponsive.</span>")
-			return
+		if(allowed(user))
+			if(broken)
+				to_chat(user, "<span class='danger'>The controls seem unresponsive.</span>")
+				return
+			else
+				pick_sign()
+				to_chat(user, "<span class='notice'>You set the barsign and close the maintenance panel.</span>")
+				panel_open = FALSE
+				return
 		else
-			pick_sign()
-			to_chat(user, "<span class='notice'>You set the barsign and close the maintenance panel.</span>")
-			panel_open = FALSE
+			to_chat(user, "<span class='info'>Access denied.</span>")
 			return
 	else
 		to_chat(user, "<span class='info'>The maintenance panel is currently closed.</span>")
@@ -90,20 +94,17 @@
 		return
 
 /obj/structure/sign/barsign/screwdriver_act(mob/user)
-	if(allowed(user))
-		if(!panel_open)
-			to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
-			set_sign(new /datum/barsign/signoff)
-			panel_open = TRUE
-		else
-			to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
-			panel_open = FALSE
+	if(!panel_open)
+		to_chat(user, "<span class='notice'>You open the maintenance panel.</span>")
+		set_sign(new /datum/barsign/signoff)
+		panel_open = TRUE
 	else
-		to_chat(user, "<span class='info'>Access denied.</span>")
-		return
+		to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
+		panel_open = FALSE
+	return
 
 /obj/structure/sign/barsign/proc/pick_sign()
-	var/list/signs = barsigns
+	var/list/signs = barsigns.Copy()
 	var/new_sign
 	if(!broken)
 		if(!emagged)
@@ -132,7 +133,7 @@
 		return
 	set_sign(new /datum/barsign/syndibarsign)
 	emagged = TRUE
-	req_access = list(ACCESS_SYNDICATE)
+	req_access += list(ACCESS_SYNDICATE)
 
 //Code below is to define useless variables for datums. It errors without these
 /datum/barsign

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -11,7 +11,6 @@
 	var/list/hiddensigns = list()
 	var/panel_open = FALSE
 	var/emagged = TRUE
-	var/bolted = FALSE
 	var/prev_sign = ""
 	var/state = 0
 
@@ -102,6 +101,64 @@
 		to_chat(user, "<span class='notice'>You close the maintenance panel.</span>")
 		panel_open = FALSE
 	return
+
+/obj/structure/sign/barsign/wrench_act(mob/user)
+	if(!panel_open)
+		to_chat(user, "<span_class='notice>You must first open the maintenance panel before trying to unbolt the barsign.</span>")
+		return
+	else
+		var/obj/item/sign/barsign/S = new(user.loc)
+		S.name = name
+		S.desc = desc
+		S.icon_state = icon_state	//The only sprite direction that exists is South.
+		S.broken = broken
+		S.emagged = emagged
+		S.req_access = req_access
+		S.panel_open = !panel_open
+		qdel(src)
+
+/obj/item/sign/barsign
+	name = "barsign"
+	desc = ""
+	icon = 'icons/obj/barsigns.dmi'
+	w_class = WEIGHT_CLASS_NORMAL
+	resistance_flags = FLAMMABLE
+	var/panel_open
+	var/broken
+	var/emagged
+
+/obj/item/sign/barsign/wrench_act(mob/user)	//construction
+	if(isturf(user.loc))
+		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
+		//The only sprite that exists is South, but we forced this in when we dismantled the barsign.
+		if(direction == "Cancel")
+			return
+		if(QDELETED(src))
+			return
+		var/obj/structure/sign/barsign/S = new(user.loc)
+		switch(direction)
+			if("North")
+				S.pixel_y = 32
+			if("East")
+				S.pixel_x = 32
+			if("South")
+				S.pixel_y = -32
+			if("West")
+				S.pixel_x = -32
+			else
+				return
+		S.name = name
+		S.desc = desc
+		S.icon_state = icon_state
+		S.broken = broken
+		S.emagged = emagged
+		S.req_access = req_access
+
+		S.panel_open = panel_open
+		to_chat(user, "You bolt \the [S] with your wrench, closing the maintenance panel in the process.")
+		qdel(src)
+	else
+		return
 
 /obj/structure/sign/barsign/proc/pick_sign()
 	var/list/signs = barsigns.Copy()

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -46,19 +46,19 @@
 /obj/structure/sign/barsign/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)
 		if(BRUTE)
-			playsound(src.loc, 'sound/effects/glasshit.ogg', 75, TRUE)
+			playsound(loc, 'sound/effects/glasshit.ogg', 75, TRUE)
 		if(BURN)
-			playsound(src.loc, 'sound/items/welder.ogg', 100, TRUE)
+			playsound(loc, 'sound/items/welder.ogg', 100, TRUE)
 
 /obj/structure/sign/barsign/attack_ai(mob/user)
-	return src.attack_hand(user)
+	return attack_hand(user)
 
 /obj/structure/sign/barsign/attack_hand(mob/user)
-	if(!src.allowed(user))
-		to_chat(user, "<span class = 'info'>Access denied.</span>")
+	if(!allowed(user))
+		to_chat(user, "<span class='info'>Access denied.</span>")
 		return
 	if(broken)
-		to_chat(user, "<span class ='danger'>The controls seem unresponsive.</span>")
+		to_chat(user, "<span class='danger'>The controls seem unresponsive.</span>")
 		return
 	pick_sign()
 
@@ -175,36 +175,30 @@
 	icon = "theouterspess"
 	desc = "This bar isn't actually located in outer space."
 
-
 /datum/barsign/slipperyshots
 	name = "Slippery Shots"
 	icon = "slipperyshots"
 	desc = "Slippery slope to drunkeness with our shots!"
-
 
 /datum/barsign/thegreytide
 	name = "The Grey Tide"
 	icon = "thegreytide"
 	desc = "Abandon your toolboxing ways and enjoy a lazy beer!"
 
-
 /datum/barsign/honkednloaded
 	name = "Honked 'n' Loaded"
 	icon = "honkednloaded"
 	desc = "Honk."
-
 
 /datum/barsign/thenest
 	name = "The Nest"
 	icon = "thenest"
 	desc = "A good place to retire for a drink after a long night of crime fighting."
 
-
 /datum/barsign/thecoderbus
 	name = "The Coderbus"
 	icon = "thecoderbus"
 	desc = "A very controversial bar known for its wide variety of constantly-changing drinks."
-
 
 /datum/barsign/theadminbus
 	name = "The Adminbus"

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -24,7 +24,7 @@
 	if(!I.use_tool(src, user, 0, volume = I.tool_volume))
 		return
 	to_chat(user, "You unfasten the sign with [I].")
-	var/obj/item/sign/S = new(src.loc)
+	var/obj/item/sign/S = new(loc)
 	S.name = name
 	S.desc = desc
 	S.icon_state = icon_state
@@ -42,7 +42,7 @@
 	resistance_flags = FLAMMABLE
 	var/sign_state = ""
 
-/obj/item/sign/attackby(obj/item/tool as obj, mob/user as mob)	//construction
+/obj/item/sign/attackby(obj/item/tool, mob/user)	//construction
 	if(istype(tool, /obj/item/screwdriver) && isturf(user.loc))
 		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
 		if(direction == "Cancel")

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -42,8 +42,9 @@
 	resistance_flags = FLAMMABLE
 	var/sign_state = ""
 
-/obj/item/sign/attackby(obj/item/tool, mob/user)	//construction
-	if(istype(tool, /obj/item/screwdriver) && isturf(user.loc))
+/obj/item/sign/screwdriver_act(mob/user)	//construction
+	if(isturf(user.loc) && !(istype(src, /obj/item/sign/barsign)))
+	// Please don't use a screwdriver on the sign/barsign.
 		var/direction = input("In which direction?", "Select direction.") in list("North", "East", "South", "West", "Cancel")
 		if(direction == "Cancel")
 			return
@@ -64,7 +65,7 @@
 		S.name = name
 		S.desc = desc
 		S.icon_state = sign_state
-		to_chat(user, "You fasten \the [S] with your [tool].")
+		to_chat(user, "You fasten \the [S] with your screwdriver.")
 		qdel(src)
 	else
 		return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Credit
A few PRs on the upstream attempted to fix this, the most recent being PR: https://github.com/ParadiseSS13/Paradise/pull/15063 . I had seen the Issue report on Paradise and tested it out on Scorpio just to see. As a smaller project, I was going to try and change it and then I saw **Tuulipommi's** PR to change it. They worked on the code with **Reviewers** and **Maintainers** from Paradise and it quite honestly appears that the code was very close to be completed and needed a few tweaks to become mergeable.

Paradise should be able to use this code as well, which is why I am directly linking both the PR and the Issue (https://github.com/ParadiseSS13/Paradise/issues/14884). Now, it may not go far enough - it doesn't allow you to _move_ the Barsign, but for now, I think it's a fair resolution. So if anyone wants to use this to PR further fixes or make it better -- please, _please_, go ahead!
## What Does This PR Do

- Sets out to resolve Issue: https://github.com/ParadiseSS13/Paradise/issues/14884.
- If the barsign has been emagged, the list of signs will include the "hidden signs"


<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Invisible sign bad.
Choose signage good.
Now with menu - perhaps as originally intended?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/69871346/103378434-48bd5800-4ab0-11eb-87d0-976da98400b9.png)
![image](https://user-images.githubusercontent.com/69871346/103378452-57a40a80-4ab0-11eb-8afb-6f8c5d92831a.png)
**The above image is out of date. I coded a chunk to do this and then realized that there was already code to do this, so I deferred to that code. That's why the language does not match up.**
![image](https://user-images.githubusercontent.com/69871346/103378472-638fcc80-4ab0-11eb-9eec-c9d5be5387b3.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Barsign's maintenance panel can be opened using a screwdriver, open Barsign only be changed via attacking with hand by either Bartender or Syndicate Agents (post-emag), open Barsign can be dismantled and moved with a wrench by anyone.
fix: Barsign can no longer turns invisible.
/:cl: