### PR TITLE
[TEST MERGE] - Code Standardisation - DNA Procedures & New DNA Type

### DIFF
--- a/code/__DEFINES/dna.dm
+++ b/code/__DEFINES/dna.dm
@@ -12,6 +12,14 @@
 #define DNA_HARDER_BOUNDS  list(1,3049,3050,4095)
 #define DNA_HARD_BOUNDS    list(1,3490,3500,4095)
 
+//DNA Types
+#define DNA_UI	0
+#define DNA_SE	1
+#define DNA_RP	2
+#define DNA_ALL 3
+
+#define DNA_RP_LENGTH 3
+
 // UI Indices (can change to mutblock style, if desired)
 #define DNA_UI_HAIR_R		1
 #define DNA_UI_HAIR_G		2

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -1045,7 +1045,7 @@
 				to_chat(H, "You have gained the ability to shapeshift into lesser hellhound form. This is a combat form with different abilities, tough but not invincible. It can regenerate itself over time by resting.")
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/raise_vampires)
 				to_chat(H, "You have gained the ability to Raise Vampires. This extremely powerful AOE ability affects all humans near you. Vampires/thralls are healed. Corpses are raised as vampires. Others are stunned, then brain damaged, then killed.")
-				H.dna.SetSEState(GLOB.jumpblock, 1)
+				H.dna.SetDNAState(GLOB.jumpblock, DNA_SE, TRUE)
 				genemutcheck(H, GLOB.jumpblock,  null, MUTCHK_FORCED)
 				H.update_mutations()
 				H.gene_stability = 100

--- a/code/datums/spells/banana_touch.dm
+++ b/code/datums/spells/banana_touch.dm
@@ -55,8 +55,8 @@
 		equip_to_slot_if_possible(new /obj/item/clothing/under/rank/clown/nodrop, slot_w_uniform, TRUE, TRUE)
 		equip_to_slot_if_possible(new /obj/item/clothing/shoes/clown_shoes/nodrop, slot_shoes, TRUE, TRUE)
 		equip_to_slot_if_possible(new /obj/item/clothing/mask/gas/clown_hat/nodrop, slot_wear_mask, TRUE, TRUE)
-	dna.SetSEState(GLOB.clumsyblock, TRUE, TRUE)
-	dna.SetSEState(GLOB.comicblock, TRUE, TRUE)
+	dna.SetDNAState(GLOB.clumsyblock, TRUE, DNA_SE, TRUE)
+	dna.SetDNAState(GLOB.comicblock, TRUE, DNA_SE, TRUE)
 	genemutcheck(src, GLOB.clumsyblock, null, MUTCHK_FORCED)
 	genemutcheck(src, GLOB.comicblock, null, MUTCHK_FORCED)
 	if(!(iswizard(src) || (mind && mind.special_role == SPECIAL_ROLE_WIZARD_APPRENTICE))) //Mutations are permanent on non-wizards. Can still be removed by genetics fuckery but not mutadone.

--- a/code/datums/spells/cluwne.dm
+++ b/code/datums/spells/cluwne.dm
@@ -27,7 +27,7 @@
 	var/obj/item/organ/internal/honktumor/cursed/tumor = new
 	tumor.insert(src)
 	mutations.Add(NERVOUS)
-	dna.SetSEState(GLOB.nervousblock, 1, 1)
+	dna.SetDNAState(GLOB.nervousblock, 1, DNA_SE, TRUE)
 	genemutcheck(src, GLOB.nervousblock, null, MUTCHK_FORCED)
 	rename_character(real_name, "cluwne")
 
@@ -62,7 +62,7 @@
 		genemutcheck(src, GLOB.clumsyblock, null, MUTCHK_FORCED)
 		genemutcheck(src, GLOB.comicblock, null, MUTCHK_FORCED)
 	mutations.Remove(NERVOUS)
-	dna.SetSEState(GLOB.nervousblock, 0)
+	dna.SetSEState(GLOB.nervousblock, FALSE)
 	genemutcheck(src, GLOB.nervousblock, null, MUTCHK_FORCED)
 
 	var/obj/item/clothing/under/U = w_uniform

--- a/code/datums/spells/cluwne.dm
+++ b/code/datums/spells/cluwne.dm
@@ -57,12 +57,12 @@
 	else
 		mutations.Remove(CLUMSY)
 		mutations.Remove(GLOB.comicblock)
-		dna.SetSEState(GLOB.clumsyblock,0)
-		dna.SetSEState(GLOB.comicblock,0)
+		dna.SetDNAState(GLOB.clumsyblock, FALSE, DNA_SE)
+		dna.SetDNAState(GLOB.comicblock, FALSE, DNA_SE)
 		genemutcheck(src, GLOB.clumsyblock, null, MUTCHK_FORCED)
 		genemutcheck(src, GLOB.comicblock, null, MUTCHK_FORCED)
 	mutations.Remove(NERVOUS)
-	dna.SetSEState(GLOB.nervousblock, FALSE)
+	dna.SetDNAState(GLOB.nervousblock, FALSE, DNA_SE)
 	genemutcheck(src, GLOB.nervousblock, null, MUTCHK_FORCED)
 
 	var/obj/item/clothing/under/U = w_uniform

--- a/code/datums/spells/mime_malaise.dm
+++ b/code/datums/spells/mime_malaise.dm
@@ -49,6 +49,6 @@
 		equip_to_slot_if_possible(new /obj/item/clothing/mask/gas/mime/nodrop, slot_wear_mask, TRUE, TRUE)
 		equip_to_slot_if_possible(new /obj/item/clothing/under/mime/nodrop, slot_w_uniform, TRUE, TRUE)
 		equip_to_slot_if_possible(new /obj/item/clothing/suit/suspenders/nodrop, slot_wear_suit, TRUE, TRUE)
-		dna.SetSEState(GLOB.muteblock , TRUE, TRUE)
+		dna.SetDNAState(GLOB.muteblock , TRUE, DNA_SE, TRUE)
 		genemutcheck(src, GLOB.muteblock , null, MUTCHK_FORCED)
 		dna.default_blocks.Add(GLOB.muteblock)

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -97,10 +97,10 @@
 
 /obj/effect/proc_holder/spell/targeted/genetic/mutate/cast(list/targets, mob/user = usr)
 	for(var/mob/living/target in targets)
-		target.dna.SetSEState(GLOB.hulkblock, 1)
+		target.dna.SetDNAState(GLOB.hulkblock, DNA_SE, TRUE)
 		genemutcheck(target, GLOB.hulkblock, null, MUTCHK_FORCED)
 		spawn(duration)
-			target.dna.SetSEState(GLOB.hulkblock, 0)
+			target.dna.SetSEState(GLOB.hulkblock, FALSE)
 			genemutcheck(target, GLOB.hulkblock, null, MUTCHK_FORCED)
 	..()
 

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -100,7 +100,7 @@
 		target.dna.SetDNAState(GLOB.hulkblock, DNA_SE, TRUE)
 		genemutcheck(target, GLOB.hulkblock, null, MUTCHK_FORCED)
 		spawn(duration)
-			target.dna.SetSEState(GLOB.hulkblock, FALSE)
+			target.dna.SetDNAState(GLOB.hulkblock, FALSE, DNA_SE)
 			genemutcheck(target, GLOB.hulkblock, null, MUTCHK_FORCED)
 	..()
 

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -2,12 +2,9 @@
 * DNA 2: The Spaghetti Strikes Back
 *
 * @author N3X15 <nexisentertainment@gmail.com>
+* @co-author Iren <uuuh I don't give out my email, find me on Discord as Iren? ;--; all I did was combine the procs?? serious shout out to N3X15! <3 >
 */
 
-// Defines which values mean "on" or "off".
-//  This is to make some of the more OP superpowers a larger PITA to activate,
-//  and to tell our new DNA datum which values to set in order to turn something
-//  on or off.
 GLOBAL_LIST_INIT(dna_activity_bounds, new(DNA_SE_LENGTH))
 GLOBAL_LIST_INIT(assigned_gene_blocks, new(DNA_SE_LENGTH))
 
@@ -24,6 +21,7 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	// DO NOT FUCK WITH THESE OR BYOND WILL EAT YOUR FACE
 	var/uni_identity = "" // Encoded UI
 	var/struc_enzymes = "" // Encoded SE
+	var/roleplay_prefs = "" //Encoded RP
 	var/unique_enzymes = "" // MD5 of player name
 
 	// Original Encoded SE, for use with Ryetalin
@@ -31,13 +29,15 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	var/list/SE_original[DNA_SE_LENGTH]
 
 	// Internal dirtiness checks
-	var/dirtyUI = 0
-	var/dirtySE = 0
+	var/dirtyUI = FALSE
+	var/dirtySE = FALSE
+	var/dirtyRP = FALSE
 
 	// Okay to read, but you're an idiot if you do.
 	// BLOCK = VALUE
 	var/list/SE[DNA_SE_LENGTH]
 	var/list/UI[DNA_UI_LENGTH]
+	var/list/RP[DNA_RP_LENGTH]
 
 	// From old dna.
 	var/blood_type = "A+"  // Should probably change to an integer => string map but I'm lazy.
@@ -55,35 +55,72 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	new_dna.blood_type = blood_type
 	new_dna.real_name = real_name
 	new_dna.species = new species.type
-	for(var/b=1;b<=DNA_SE_LENGTH;b++)
+	for(var/b=1;b<=DNA_SE_LENGTH;b++) //Should DNA_RP be involved in here somewhere? Iunno!
 		new_dna.SE[b]=SE[b]
 		if(b<=DNA_UI_LENGTH)
 			new_dna.UI[b]=UI[b]
-	new_dna.UpdateUI()
-	new_dna.UpdateSE()
+	new_dna.UpdateDNA(DNA_ALL)
 	return new_dna
 
 ///////////////////////////////////////
-// UNIQUE IDENTITY
+// UPDATE and RESET types of DNA
 ///////////////////////////////////////
 
-// Create random UI.
-/datum/dna/proc/ResetUI(defer = FALSE)
-	for(var/i=1,i<=DNA_UI_LENGTH,i++)
-		switch(i)
-			if(DNA_UI_SKIN_TONE)
-				SetUIValueRange(DNA_UI_SKIN_TONE, rand(1, 220), 220, 1) // Otherwise, it gets fucked
-			else
-				UI[i]=rand(0,4095)
-	if(!defer)
-		UpdateUI()
+/datum/dna/proc/ResetDNA(dna_type, defer = FALSE)
+	ASSERT(dna_type >= 0)
+	ASSERT(dna_type <= 3)
+	switch(dna_type)
+		if(DNA_UI)					// Create a random UI
+			for(var/i =1, i <= DNA_UI_LENGTH, i++)
+				if(i == DNA_UI_SKIN_TONE)
+					SetDNAValueRange(DNA_UI_SKIN_TONE, rand(1, 220), 220, DNA_UI, TRUE) // Otherwise, it gets fucked
+				else
+					UI[i] = rand(0, 4095)
+			if(!defer)
+				UpdateDNA(DNA_UI)
+		if(DNA_SE)				// "Zeroes out" all of the SE Blocks
+			for(var/i = 1, i <= DNA_SE_LENGTH, i++)
+				SetDNAValue(i, rand(1, 1024), TRUE, DNA_SE)
+			UpdateDNA(DNA_SE)
+		if(DNA_RP)
+			for(var/i = 1, i <= DNA_RP_LENGTH, i++)
+				SetDNAValue(i, rand(1, 1024), TRUE, DNA_RP)
+			UpdateDNA(DNA_RP)
+		if(DNA_ALL) //Recurse! Reeeecccuuuuurrrrsssseeee! AHAHAHAHAHAHAHAHA!
+			ResetDNA(DNA_UI)
+			ResetDNA(DNA_SE)
+			ResetDNA(DNA_RP)
 
-/datum/dna/proc/ResetUIFrom(mob/living/carbon/human/character)
-	// INITIALIZE!
-	ResetUI(1)
-	// Hair
-	// FIXME:  Species-specific defaults pls
-	var/obj/item/organ/external/head/H = character.get_organ("head")
+/datum/dna/proc/UpdateDNA(dna_type)
+	ASSERT(dna_type >= 0)
+	ASSERT(dna_type <= 3)
+	switch(dna_type)
+		if(DNA_UI)
+			uni_identity = ""
+			for(var/block in UI)
+				uni_identity += EncodeDNABlock(block)
+			dirtyUI = FALSE
+		if(DNA_SE)
+			struc_enzymes = ""
+			for(var/block in SE)
+				struc_enzymes += EncodeDNABlock(block)
+			dirtySE = FALSE
+		if(DNA_RP)
+			roleplay_prefs = ""
+			for(var/block in RP)
+				roleplay_prefs += EncodeDNABlock(block)
+			dirtyRP = FALSE
+		if(DNA_ALL) //Heck you again!
+			UpdateDNA(DNA_UI)
+			UpdateDNA(DNA_SE)
+			UpdateDNA(DNA_RP)
+
+
+/datum/dna/proc/ResetDNAFrom(mob/living/carbon/human/character, dna_type)
+	if(dna_type != DNA_UI)
+		return
+	ResetDNA(DNA_UI, TRUE)		// INITIALIZE!
+	var/obj/item/organ/external/head/H = character.get_organ("head")	// Hair // FIXME:  Species-specific defaults pls
 	var/obj/item/organ/internal/eyes/eyes_organ = character.get_int_organ(/obj/item/organ/internal/eyes)
 
 	/*// Body Accessory
@@ -102,112 +139,149 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	head_traits_to_dna(H)
 	eye_color_to_dna(eyes_organ)
 
-	SetUIValueRange(DNA_UI_SKIN_R,		color2R(character.skin_colour),			255,	1)
-	SetUIValueRange(DNA_UI_SKIN_G,		color2G(character.skin_colour),			255,	1)
-	SetUIValueRange(DNA_UI_SKIN_B,		color2B(character.skin_colour),			255,	1)
+	SetDNAValueRange(DNA_UI_SKIN_R,		color2R(character.skin_colour),			255,	DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_SKIN_G,		color2G(character.skin_colour),			255,	DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_SKIN_B,		color2B(character.skin_colour),			255,	DNA_UI,	TRUE)
 
-	SetUIValueRange(DNA_UI_HEAD_MARK_R,	color2R(character.m_colours["head"]),	255,	1)
-	SetUIValueRange(DNA_UI_HEAD_MARK_G,	color2G(character.m_colours["head"]),	255,	1)
-	SetUIValueRange(DNA_UI_HEAD_MARK_B,	color2B(character.m_colours["head"]),	255,	1)
+	SetDNAValueRange(DNA_UI_HEAD_MARK_R,	color2R(character.m_colours["head"]),	255,	DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_HEAD_MARK_G,	color2G(character.m_colours["head"]),	255,	DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_HEAD_MARK_B,	color2B(character.m_colours["head"]),	255,	DNA_UI,	TRUE)
 
-	SetUIValueRange(DNA_UI_BODY_MARK_R,	color2R(character.m_colours["body"]),	255,	1)
-	SetUIValueRange(DNA_UI_BODY_MARK_G,	color2G(character.m_colours["body"]),	255,	1)
-	SetUIValueRange(DNA_UI_BODY_MARK_B,	color2B(character.m_colours["body"]),	255,	1)
+	SetDNAValueRange(DNA_UI_BODY_MARK_R,	color2R(character.m_colours["body"]),	255,	DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_BODY_MARK_G,	color2G(character.m_colours["body"]),	255,	DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_BODY_MARK_B,	color2B(character.m_colours["body"]),	255,	DNA_UI,	TRUE)
 
-	SetUIValueRange(DNA_UI_TAIL_MARK_R,	color2R(character.m_colours["tail"]),	255,	1)
-	SetUIValueRange(DNA_UI_TAIL_MARK_G,	color2G(character.m_colours["tail"]),	255,	1)
-	SetUIValueRange(DNA_UI_TAIL_MARK_B,	color2B(character.m_colours["tail"]),	255,	1)
+	SetDNAValueRange(DNA_UI_TAIL_MARK_R,	color2R(character.m_colours["tail"]),	255,	DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_TAIL_MARK_G,	color2G(character.m_colours["tail"]),	255,	DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_TAIL_MARK_B,	color2B(character.m_colours["tail"]),	255,	DNA_UI,	TRUE)
 
-	SetUIValueRange(DNA_UI_SKIN_TONE,	35-character.s_tone,	220,	1) // Value can be negative.
+	SetDNAValueRange(DNA_UI_SKIN_TONE,	35-character.s_tone,	220,	DNA_UI,	TRUE) // Value can be negative.
 
-	/*SetUIValueRange(DNA_UI_BACC_STYLE,	bodyacc,	GLOB.facial_hair_styles_list.len,	1)*/
-	SetUIValueRange(DNA_UI_HEAD_MARK_STYLE,	head_marks,		GLOB.marking_styles_list.len,		1)
-	SetUIValueRange(DNA_UI_BODY_MARK_STYLE,	body_marks,		GLOB.marking_styles_list.len,		1)
-	SetUIValueRange(DNA_UI_TAIL_MARK_STYLE,	tail_marks,		GLOB.marking_styles_list.len,		1)
+	/*SetDNAValueRange(DNA_UI_BACC_STYLE,	bodyacc,	GLOB.facial_hair_styles_list.len,	DNA_UI,	TRUE)*/
+	SetDNAValueRange(DNA_UI_HEAD_MARK_STYLE,	head_marks,		GLOB.marking_styles_list.len,		DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_BODY_MARK_STYLE,	body_marks,		GLOB.marking_styles_list.len,		DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_TAIL_MARK_STYLE,	tail_marks,		GLOB.marking_styles_list.len,		DNA_UI,	TRUE)
 
 	//Set the Gender
 	switch(character.gender)
 		if(FEMALE)
-			SetUITriState(DNA_UI_GENDER, DNA_GENDER_FEMALE, 1)
+			SetDNATriState(DNA_UI_GENDER, DNA_GENDER_FEMALE, DNA_UI, TRUE)
 		if(MALE)
-			SetUITriState(DNA_UI_GENDER, DNA_GENDER_MALE, 1)
+			SetDNATriState(DNA_UI_GENDER, DNA_GENDER_MALE, DNA_UI, TRUE)
 		if(PLURAL)
-			SetUITriState(DNA_UI_GENDER, DNA_GENDER_PLURAL, 1)
+			SetDNATriState(DNA_UI_GENDER, DNA_GENDER_PLURAL, DNA_UI, TRUE)
 
 
-	UpdateUI()
+	UpdateDNA(DNA_UI)
 
-// Set a DNA UI block's raw value.
-/datum/dna/proc/SetUIValue(block, value, defer = FALSE)
-	if(block <= 0)
+
+/datum/dna/proc/ValidCheck(block, dna_type)
+	if(block <= 0 || dna_type < 0 || dna_type > 2 || dna_type == null)
+		return FALSE
+	else
+		return TRUE
+
+///////////////////////////////////////
+// SET and GET values for DNA blocks
+///////////////////////////////////////
+
+// Set a DNA block's raw value.
+/datum/dna/proc/SetDNAValue(block, value, dna_type, defer = FALSE)
+	if(!ValidCheck(block, dna_type))
 		return
 	ASSERT(value > 0)
 	ASSERT(value <= 4095)
-	UI[block]=value
-	dirtyUI = 1
+	switch(dna_type)
+		if(DNA_UI)
+			UI[block] = value
+			dirtyUI = TRUE
+		if(DNA_SE)
+			SE[block] = value
+			dirtySE = TRUE
+		if(DNA_RP)
+			RP[block] = value
+			dirtyRP = TRUE
 	if(!defer)
-		UpdateUI()
+		UpdateDNA(dna_type)
 
-// Get a DNA UI block's raw value.
-/datum/dna/proc/GetUIValue(block)
-	if(block <= 0)
+// Get a DNA block's raw value.
+/datum/dna/proc/GetDNAValue(block, dna_type)
+	if(!ValidCheck(block, dna_type))
 		return FALSE
-	return UI[block]
+	switch(dna_type)
+		if(DNA_UI)
+			return UI[block]
+		if(DNA_SE)
+			return SE[block]
+		if(DNA_RP)
+			return RP[block]
 
-// Set a DNA UI block's value, given a value and a max possible value.
-// Used in hair and facial styles (value being the index and maxvalue being the len of the hairstyle list)
-/datum/dna/proc/SetUIValueRange(block, value, maxvalue, defer = FALSE)
-	if(block <= 0)
+// Set a DNA block's value, given a value and a max possible value
+/datum/dna/proc/SetDNAValueRange(block, value, maxvalue, dna_type, defer = FALSE)
+	if(!ValidCheck(block, dna_type) || !value)
 		return
-	if(value == 0)
-		value = 1
 	ASSERT(maxvalue <= 4095)
 	var/range = (4095 / maxvalue)
-	if(value)
-		SetUIValue(block,round(value * range), defer)
+	switch(dna_type)
+		if(DNA_UI)			// Used in hair and facial styles (value being the index and maxvalue being the len of the hairstyle list)
+			if(value == 0)
+				value = 1
+			SetDNAValue(block, round(value * range), DNA_UI, defer)
+		if(DNA_SE)		// Might be used for species?
+			SetDNAValue(block, round(value * range) - rand(1, range - 1), DNA_SE)
+		if(DNA_RP)
+			SetDNAValue(block, round(value * range), DNA_RP)
 
 // Getter version of above.
-/datum/dna/proc/GetUIValueRange(block, maxvalue)
-	if(block <= 0)
+/datum/dna/proc/GetDNAValueRange(block, maxvalue, dna_type)
+	if(!ValidCheck(block, dna_type))
 		return FALSE
-	var/value = GetUIValue(block)
+	var/value = GetDNAValue(block, dna_type)
 	return round(1 + (value / 4096) * maxvalue)
 
-// Is the UI gene "on" or "off"?
-// For UI, this is simply a check of if the value is > 2050.
-/datum/dna/proc/GetUIState(block)
-	if(block <= 0)
-		return
-	return UI[block] > 2050
+/*
+ * STATE BLOCKS
+ * These procs set and get values for both binary and trinary DNA-stated blocks.else
+ */
 
-
-// Set UI gene "on" (1) or "off" (0)
-/datum/dna/proc/SetUIState(block, on, defer = FALSE)
-	if(block <= 0)
+// Set UI gene "on" (TRUE) or "off" (FALSE)
+/datum/dna/proc/SetDNAState(block, on, dna_type, defer = FALSE)
+	if(!ValidCheck(block,dna_type))
 		return
 	var/val
-	if(on)
-		val = rand(2050, 4095)
-	else
-		val=rand(1, 2049)
-	SetUIValue(block, val, defer)
+	switch(dna_type)
+		if(DNA_UI)
+			if(on)		//Are we setting the state of this block to "on" (TRUE)?
+				val = rand(2050, 4095)
+			else		//Or to "off" (FALSE)?
+				val = rand(1, 2049)
+		if(DNA_SE)
+			var/list/BOUNDS=GetDNABounds(block)
+			if(on)
+				val = rand(BOUNDS[DNA_ON_LOWERBOUND], BOUNDS[DNA_ON_UPPERBOUND])
+			else
+				val = rand(1, BOUNDS[DNA_OFF_UPPERBOUND])
+		if(DNA_RP)
+			val = on		// DNA_RP is simple, okay? "on" is on and "off" is off!
+	SetDNAValue(block, val, dna_type, defer)
 
-//Get Tri State Block State
-/datum/dna/proc/GetUITriState(block)
-	if(block <= 0)
+// Is the block "on" (TRUE) or "off" (FALSE)?
+/datum/dna/proc/GetDNAState(block, dna_type)
+	if(!ValidCheck(block,dna_type))
 		return
-	var/val = GetUIValue(block)
-	switch(val)
-		if(1 to 1395)
-			return 0
-		if(1396 to 2760)
-			return 1
-		if(2761 to 4095)
-			return 2
+	switch(dna_type)
+		if(DNA_UI)			// For UI, this is simply a check of if the value is > 2050.
+			return UI[block] > 2050
+		if(DNA_SE)		//(Un-assigned genes are always off.)
+			var/list/BOUNDS = GetDNABounds(block)
+			var/value = GetDNAValue(block, DNA_SE)
+			return (value >= BOUNDS[DNA_ON_LOWERBOUND])
+		if(DNA_RP)			//Look, it's simple!
+			return RP[block] > 0
 
-// Set Trinary UI Block State
-/datum/dna/proc/SetUITriState(block, value, defer = FALSE)
-	if(block <= 0)
+// Set Trinary DNA Block State
+/datum/dna/proc/SetDNATriState(block, value, dna_type, defer = FALSE)
+	if(!ValidCheck(block, dna_type))
 		return
 	ASSERT(value >= 0)
 	ASSERT(value <= 2)
@@ -219,168 +293,78 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 			val = rand(1396, 2760)
 		if(2)
 			val = rand(2761, 4095)
-	SetUIValue(block, val, defer)
+	SetDNAValue(block, val, dna_type, defer)
 
+//Get TriState Block State
+/datum/dna/proc/GetDNATriState(block, dna_type)
+	if(!ValidCheck(block, dna_type))
+		return
+	var/val = GetDNAValue(block, dna_type)
+	switch(val)
+		if(1 to 1395)
+			return 0
+		if(1396 to 2760)
+			return 1
+		if(2761 to 4095)
+			return 2
 
-// Get a hex-encoded UI block.
-/datum/dna/proc/GetUIBlock(block)
-	return EncodeDNABlock(GetUIValue(block))
+/////////////////////////////////////////
+// ENCODE and SET-GET sub-blocks of DNA
+/////////////////////////////////////////
+
+// Hex-Encode a DNA block - wait which block? oh, that's in the code below, because that makes sense. Sure, why not!
+/proc/EncodeDNABlock(value)
+	return add_zero2(num2hex(value, 1), 3)
+
+// Get a hex-encoded DNA block.
+/datum/dna/proc/GetDNABlock(block, dna_type)
+	if(!ValidCheck(block, dna_type))
+		return
+	return EncodeDNABlock(GetDNAValue(block, dna_type))
 
 // Do not use this unless you absolutely have to.
-// Set a block from a hex string.  This is inefficient.  If you can, use SetUIValue().
+// Set a block from a hex string.  This is inefficient.  If you can, use SetDNAValue().
 // Used in DNA modifiers.
-/datum/dna/proc/SetUIBlock(block, value, defer = FALSE)
-	if(block <= 0)
+/datum/dna/proc/SetDNABlock(block, value, dna_type, defer = FALSE)
+	if(!ValidCheck(block, dna_type))
 		return
-	return SetUIValue(block, hex2num(value), defer)
+	return SetDNAValue(block, hex2num(value), dna_type, defer)
 
 // Get a sub-block from a block.
-/datum/dna/proc/GetUISubBlock(block, subBlock)
-	return copytext(GetUIBlock(block), subBlock, subBlock + 1)
+/datum/dna/proc/GetDNASubBlock(block, subBlock, dna_type)
+	if(!ValidCheck(block, dna_type))
+		return
+	return copytext(GetDNABlock(block, dna_type), subBlock, subBlock + 1)
 
 // Do not use this unless you absolutely have to.
-// Set a block from a hex string.  This is inefficient.  If you can, use SetUIValue().
+// Set a block from a hex string.  This is inefficient.  If you can, use SetDNAValue().
 // Used in DNA modifiers.
-/datum/dna/proc/SetUISubBlock(block, subBlock, newSubBlock, defer = FALSE)
-	if(block <= 0)
+/datum/dna/proc/SetDNASubBlock(block, subBlock, newSubBlock, dna_type, defer = FALSE)
+	if(!ValidCheck(block, dna_type))
 		return
-	var/oldBlock = GetUIBlock(block)
+	var/oldBlock = GetDNABlock(block, dna_type)
 	var/newBlock = ""
 	for(var/i = 1, i <= length(oldBlock), i++)
 		if(i==subBlock)
 			newBlock += newSubBlock
 		else
 			newBlock += copytext(oldBlock, i, i + 1)
-	SetUIBlock(block, newBlock, defer)
+	SetDNABlock(block, newBlock, dna_type, defer)
+
 
 ///////////////////////////////////////
-// STRUCTURAL ENZYMES
+// OTHER procs for DNA fuctionality
 ///////////////////////////////////////
-
-// "Zeroes out" all of the blocks.
-/datum/dna/proc/ResetSE()
-	for(var/i = 1, i <= DNA_SE_LENGTH, i++)
-		SetSEValue(i, rand(1, 1024), 1)
-	UpdateSE()
-
-// Set a DNA SE block's raw value.
-/datum/dna/proc/SetSEValue(block, value, defer = FALSE)
-
-	if(block<=0)
-		return
-	ASSERT(value >= 0)
-	ASSERT(value <= 4095)
-	SE[block] = value
-	dirtySE = 1
-	if(!defer)
-		UpdateSE()
-	//testing("SetSEBlock([block],[value],[defer]): [value] -> [GetSEValue(block)]")
-
-// Get a DNA SE block's raw value.
-/datum/dna/proc/GetSEValue(block)
-	if(block <= 0)
-		return FALSE
-	return SE[block]
-
-// Set a DNA SE block's value, given a value and a max possible value.
-// Might be used for species?
-/datum/dna/proc/SetSEValueRange(block, value, maxvalue)
-	if(block <= 0)
-		return
-	ASSERT(maxvalue <= 4095)
-	var/range = round(4095 / maxvalue)
-	if(value)
-		SetSEValue(block, value * range - rand(1, range - 1))
-
-// Getter version of above.
-/datum/dna/proc/GetSEValueRange(block, maxvalue)
-	if(block <= 0)
-		return FALSE
-	var/value = GetSEValue(block)
-	return round(1 + (value / 4096) * maxvalue)
-
-// Is the block "on" (1) or "off" (0)? (Un-assigned genes are always off.)
-/datum/dna/proc/GetSEState(block)
-	if(block <= 0)
-		return FALSE
-	var/list/BOUNDS = GetDNABounds(block)
-	var/value = GetSEValue(block)
-	return (value >= BOUNDS[DNA_ON_LOWERBOUND])
-
-// Set a block "on" or "off".
-/datum/dna/proc/SetSEState(block, on, defer = FALSE)
-	if(block <= 0)
-		return
-	var/list/BOUNDS=GetDNABounds(block)
-	var/val
-	if(on)
-		val = rand(BOUNDS[DNA_ON_LOWERBOUND], BOUNDS[DNA_ON_UPPERBOUND])
-	else
-		val = rand(1, BOUNDS[DNA_OFF_UPPERBOUND])
-	SetSEValue(block, val, defer)
-
-// Get hex-encoded SE block.
-/datum/dna/proc/GetSEBlock(block)
-	return EncodeDNABlock(GetSEValue(block))
-
-// Do not use this unless you absolutely have to.
-// Set a block from a hex string.  This is inefficient.  If you can, use SetUIValue().
-// Used in DNA modifiers.
-/datum/dna/proc/SetSEBlock(block, value, defer = FALSE)
-	if(block <= 0)
-		return
-	var/nval=hex2num(value)
-	//testing("SetSEBlock([block],[value],[defer]): [value] -> [nval]")
-	return SetSEValue(block, nval, defer)
-
-/datum/dna/proc/GetSESubBlock(block, subBlock)
-	return copytext(GetSEBlock(block), subBlock, subBlock + 1)
-
-// Do not use this unless you absolutely have to.
-// Set a sub-block from a hex character.  This is inefficient.  If you can, use SetUIValue().
-// Used in DNA modifiers.
-/datum/dna/proc/SetSESubBlock(block, subBlock, newSubBlock, defer = FALSE)
-	if(block <= 0)
-		return
-	var/oldBlock=GetSEBlock(block)
-	var/newBlock = ""
-	for(var/i = 1, i <= length(oldBlock), i++)
-		if(i==subBlock)
-			newBlock+=newSubBlock
-		else
-			newBlock += copytext(oldBlock, i, i + 1)
-	//testing("SetSESubBlock([block],[subBlock],[newSubBlock],[defer]): [oldBlock] -> [newBlock]")
-	SetSEBlock(block, newBlock, defer)
-
-
-/proc/EncodeDNABlock(value)
-	return add_zero2(num2hex(value, 1), 3)
-
-/datum/dna/proc/UpdateUI()
-	uni_identity = ""
-	for(var/block in UI)
-		uni_identity += EncodeDNABlock(block)
-	//testing("New UI: [uni_identity]")
-	dirtyUI = 0
-
-/datum/dna/proc/UpdateSE()
-	//var/oldse=struc_enzymes
-	struc_enzymes = ""
-	for(var/block in SE)
-		struc_enzymes += EncodeDNABlock(block)
-	//testing("Old SE: [oldse]")
-	//testing("New SE: [struc_enzymes]")
-	dirtySE = 0
 
 // BACK-COMPAT!
 //  Just checks our character has all the crap it needs.
 /datum/dna/proc/check_integrity(mob/living/carbon/human/character)
 	if(character)
 		if(UI.len != DNA_UI_LENGTH)
-			ResetUIFrom(character)
+			ResetDNAFrom(character, DNA_UI)
 
 		if(length(struc_enzymes)!= 3 * DNA_SE_LENGTH)
-			ResetSE()
+			ResetDNA(DNA_SE)
 
 		if(length(unique_enzymes) != 32)
 			unique_enzymes = md5(character.real_name)
@@ -395,15 +379,11 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 //    ready_dna is (hopefully) only used on mob creation, and sets the struc_enzymes_original and SE_original only once - Bone White
 
 /datum/dna/proc/ready_dna(mob/living/carbon/human/character, flatten_SE = 1)
-
-	ResetUIFrom(character)
-
+	ResetDNAFrom(character, DNA_UI)
 	if(flatten_SE)
-		ResetSE()
-
+		ResetDNA(DNA_SE)
 	struc_enzymes_original = struc_enzymes // sets the original struc_enzymes when ready_dna is called
 	SE_original = SE.Copy()
-
 	unique_enzymes = md5(character.real_name)
 	GLOB.reg_dna[unique_enzymes] = character.real_name
 
@@ -424,8 +404,7 @@ GLOBAL_LIST_EMPTY(bad_blocks)
 	// The de-serializer is unlikely to tamper with the lists
 	SE = data["SE"]
 	UI = data["UI"]
-	UpdateUI()
-	UpdateSE()
+	UpdateDNA(DNA_ALL)
 	var/datum/species/S = data["species"]
 	species = new S
 	blood_type = data["blood_type"]

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -2,7 +2,6 @@
 * DNA 2: The Spaghetti Strikes Back
 *
 * @author N3X15 <nexisentertainment@gmail.com>
-* @co-author Iren <uuuh I don't give out my email, find me on Discord as Iren? ;--; all I did was combine the procs?? serious shout out to N3X15! <3 >
 */
 
 GLOBAL_LIST_INIT(dna_activity_bounds, new(DNA_SE_LENGTH))

--- a/code/game/dna/dna2_domutcheck.dm
+++ b/code/game/dna/dna2_domutcheck.dm
@@ -32,7 +32,7 @@
 		return FALSE
 
 	// Current state
-	var/gene_active = M.dna.GetSEState(gene.block)
+	var/gene_active = M.dna.GetDNAState(gene.block, DNA_SE)
 
 	// Sanity checks, don't skip.
 	if(!gene.can_activate(M,flags) && gene_active)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -41,7 +41,7 @@
 	if(!M || !M.dna)
 		return
 	M.dna.check_integrity()
-	M.dna.SetUIValue(rand(1, DNA_UI_LENGTH), rand(1, 4095))
+	M.dna.SetDNAValue(rand(1, DNA_UI_LENGTH), rand(1, 4095), DNA_UI)
 
 // Scramble UI or SE.
 /proc/scramble(UI, mob/M, prob)
@@ -51,7 +51,7 @@
 	if(UI)
 		for(var/i = 1, i <= DNA_UI_LENGTH - 1, i++)
 			if(prob(prob))
-				M.dna.SetUIValue(i, rand(1, 4095), 1)
+				M.dna.SetDNAValue(i, rand(1, 4095), DNA_UI, TRUE)
 		M.dna.UpdateDNA(DNA_UI)
 		M.UpdateAppearance()
 

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -26,7 +26,7 @@
 		return
 	M.dna.check_integrity()
 	var/block = pick(GLOB.bad_blocks)
-	M.dna.SetSEState(block, 1)
+	M.dna.SetDNAState(block, DNA_SE, TRUE)
 
 // Give Random Good Mutation to M
 /proc/randmutg(mob/living/M)
@@ -34,7 +34,7 @@
 		return
 	M.dna.check_integrity()
 	var/block = pick(GLOB.good_blocks)
-	M.dna.SetSEState(block, 1)
+	M.dna.SetDNAState(block, DNA_SE, TRUE)
 
 // Random Appearance Mutation
 /proc/randmuti(mob/living/M)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -52,14 +52,14 @@
 		for(var/i = 1, i <= DNA_UI_LENGTH - 1, i++)
 			if(prob(prob))
 				M.dna.SetUIValue(i, rand(1, 4095), 1)
-		M.dna.UpdateUI()
+		M.dna.UpdateDNA(DNA_UI)
 		M.UpdateAppearance()
 
 	else
 		for(var/i = 1, i <= DNA_SE_LENGTH - 1, i++)
 			if(prob(prob))
 				M.dna.SetSEValue(i, rand(1, 4095), 1)
-		M.dna.UpdateSE()
+		M.dna.UpdateDNA(DNA_SE)
 		domutcheck(M, null)
 
 // I haven't yet figured out what the fuck this is supposed to do.
@@ -131,7 +131,7 @@
 	if(istype(src, /mob/living/carbon/human)) // WHY?!
 		if(UI!=null)
 			dna.UI = UI
-			dna.UpdateUI()
+			dna.UpdateDNA(DNA_UI)
 		dna.check_integrity()
 		var/mob/living/carbon/human/H = src
 		var/obj/item/organ/external/head/head_organ = H.get_organ("head")

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -58,7 +58,7 @@
 	else
 		for(var/i = 1, i <= DNA_SE_LENGTH - 1, i++)
 			if(prob(prob))
-				M.dna.SetSEValue(i, rand(1, 4095), 1)
+				M.dna.SetDNAValue(i, rand(1, 4095), DNA_SE, TRUE)
 		M.dna.UpdateDNA(DNA_SE)
 		domutcheck(M, null)
 
@@ -150,7 +150,7 @@
 
 		H.s_tone   = 35 - dna.GetUIValueRange(DNA_UI_SKIN_TONE, 220) // Value can be negative.
 
-		switch(dna.GetUITriState(DNA_UI_GENDER))
+		switch(dna.GetDNATriState(DNA_UI_GENDER, DNA_UI))
 			if(DNA_GENDER_FEMALE)
 				H.change_gender(FEMALE, FALSE)
 			if(DNA_GENDER_MALE)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -142,13 +142,13 @@
 			dna.write_eyes_attributes(eye_organ)
 		H.update_eyes()
 
-		H.skin_colour = rgb(dna.GetUIValueRange(DNA_UI_SKIN_R, 255), dna.GetUIValueRange(DNA_UI_SKIN_G, 255), dna.GetUIValueRange(DNA_UI_SKIN_B, 255))
+		H.skin_colour = rgb(dna.GetDNAValue(DNA_UI_SKIN_R, 255, DNA_UI), dna.GetDNAValue(DNA_UI_SKIN_G, 255, DNA_UI), dna.GetDNAValue(DNA_UI_SKIN_B, 255, DNA_UI))
 
-		H.m_colours["head"] = rgb(dna.GetUIValueRange(DNA_UI_HEAD_MARK_R, 255), dna.GetUIValueRange(DNA_UI_HEAD_MARK_G, 255), dna.GetUIValueRange(DNA_UI_HEAD_MARK_B, 255))
-		H.m_colours["body"] = rgb(dna.GetUIValueRange(DNA_UI_BODY_MARK_R, 255), dna.GetUIValueRange(DNA_UI_BODY_MARK_G, 255), dna.GetUIValueRange(DNA_UI_BODY_MARK_B, 255))
-		H.m_colours["tail"] = rgb(dna.GetUIValueRange(DNA_UI_TAIL_MARK_R, 255), dna.GetUIValueRange(DNA_UI_TAIL_MARK_G, 255), dna.GetUIValueRange(DNA_UI_TAIL_MARK_B, 255))
+		H.m_colours["head"] = rgb(dna.GetDNAValue(DNA_UI_HEAD_MARK_R, 255, DNA_UI), dna.GetDNAValue(DNA_UI_HEAD_MARK_G, 255, DNA_UI), dna.GetDNAValue(DNA_UI_HEAD_MARK_B, 255, DNA_UI))
+		H.m_colours["body"] = rgb(dna.GetDNAValue(DNA_UI_BODY_MARK_R, 255, DNA_UI), dna.GetDNAValue(DNA_UI_BODY_MARK_G, 255, DNA_UI), dna.GetDNAValue(DNA_UI_BODY_MARK_B, 255, DNA_UI))
+		H.m_colours["tail"] = rgb(dna.GetDNAValue(DNA_UI_TAIL_MARK_R, 255, DNA_UI), dna.GetDNAValue(DNA_UI_TAIL_MARK_G, 255, DNA_UI), dna.GetDNAValue(DNA_UI_TAIL_MARK_B, 255, DNA_UI))
 
-		H.s_tone   = 35 - dna.GetUIValueRange(DNA_UI_SKIN_TONE, 220) // Value can be negative.
+		H.s_tone   = 35 - dna.GetDNAValue(DNA_UI_SKIN_TONE, 220, DNA_UI) // Value can be negative.
 
 		switch(dna.GetDNATriState(DNA_UI_GENDER, DNA_UI))
 			if(DNA_GENDER_FEMALE)
@@ -159,15 +159,15 @@
 				H.change_gender(PLURAL, FALSE)
 
 		//Head Markings
-		var/head_marks = dna.GetUIValueRange(DNA_UI_HEAD_MARK_STYLE, GLOB.marking_styles_list.len)
+		var/head_marks = dna.GetDNAValue(DNA_UI_HEAD_MARK_STYLE, GLOB.marking_styles_list.len, DNA_UI)
 		if((head_marks > 0) && (head_marks <= GLOB.marking_styles_list.len))
 			H.m_styles["head"] = GLOB.marking_styles_list[head_marks]
 		//Body Markings
-		var/body_marks = dna.GetUIValueRange(DNA_UI_BODY_MARK_STYLE, GLOB.marking_styles_list.len)
+		var/body_marks = dna.GetDNAValue(DNA_UI_BODY_MARK_STYLE, GLOB.marking_styles_list.len, DNA_UI)
 		if((body_marks > 0) && (body_marks <= GLOB.marking_styles_list.len))
 			H.m_styles["body"] = GLOB.marking_styles_list[body_marks]
 		//Tail Markings
-		var/tail_marks = dna.GetUIValueRange(DNA_UI_TAIL_MARK_STYLE, GLOB.marking_styles_list.len)
+		var/tail_marks = dna.GetDNAValue(DNA_UI_TAIL_MARK_STYLE, GLOB.marking_styles_list.len, DNA_UI)
 		if((tail_marks > 0) && (tail_marks <= GLOB.marking_styles_list.len))
 			H.m_styles["tail"] = GLOB.marking_styles_list[tail_marks]
 
@@ -189,31 +189,31 @@
 /datum/dna/proc/write_head_attributes(obj/item/organ/external/head/head_organ)
 
 	//Hair
-	var/hair = GetUIValueRange(DNA_UI_HAIR_STYLE,GLOB.hair_styles_full_list.len)
+	var/hair = GetDNAValue(DNA_UI_HAIR_STYLE, GLOB.hair_styles_full_list.len, DNA_UI)
 	if((hair > 0) && (hair <= GLOB.hair_styles_full_list.len))
 		head_organ.h_style = GLOB.hair_styles_full_list[hair]
 
-	head_organ.hair_colour = rgb(head_organ.dna.GetUIValueRange(DNA_UI_HAIR_R, 255), head_organ.dna.GetUIValueRange(DNA_UI_HAIR_G, 255), head_organ.dna.GetUIValueRange(DNA_UI_HAIR_B, 255))
-	head_organ.sec_hair_colour = rgb(head_organ.dna.GetUIValueRange(DNA_UI_HAIR2_R, 255), head_organ.dna.GetUIValueRange(DNA_UI_HAIR2_G, 255), head_organ.dna.GetUIValueRange(DNA_UI_HAIR2_B, 255))
+	head_organ.hair_colour = rgb(head_organ.dna.GetDNAValue(DNA_UI_HAIR_R, 255, DNA_UI), head_organ.dna.GetDNAValue(DNA_UI_HAIR_G, 255, DNA_UI), head_organ.dna.GetDNAValue(DNA_UI_HAIR_B, 255, DNA_UI))
+	head_organ.sec_hair_colour = rgb(head_organ.dna.GetDNAValue(DNA_UI_HAIR2_R, 255, DNA_UI), head_organ.dna.GetDNAValue(DNA_UI_HAIR2_G, 255, DNA_UI), head_organ.dna.GetDNAValue(DNA_UI_HAIR2_B, 255, DNA_UI))
 
 	//Facial Hair
-	var/beard = GetUIValueRange(DNA_UI_BEARD_STYLE,GLOB.facial_hair_styles_list.len)
+	var/beard = GetDNAValue(DNA_UI_BEARD_STYLE, GLOB.facial_hair_styles_list.len, DNA_UI)
 	if((beard > 0) && (beard <= GLOB.facial_hair_styles_list.len))
 		head_organ.f_style = GLOB.facial_hair_styles_list[beard]
 
-	head_organ.facial_colour = rgb(head_organ.dna.GetUIValueRange(DNA_UI_BEARD_R, 255), head_organ.dna.GetUIValueRange(DNA_UI_BEARD_G, 255), head_organ.dna.GetUIValueRange(DNA_UI_BEARD_B, 255))
-	head_organ.sec_facial_colour = rgb(head_organ.dna.GetUIValueRange(DNA_UI_BEARD2_R, 255), head_organ.dna.GetUIValueRange(DNA_UI_BEARD2_G, 255), head_organ.dna.GetUIValueRange(DNA_UI_BEARD2_B, 255))
+	head_organ.facial_colour = rgb(head_organ.dna.GetDNAValue(DNA_UI_BEARD_R, 255, DNA_UI), head_organ.dna.GetDNAValue(DNA_UI_BEARD_G, 255, DNA_UI), head_organ.dna.GetDNAValue(DNA_UI_BEARD_B, 255, DNA_UI))
+	head_organ.sec_facial_colour = rgb(head_organ.dna.GetDNAValue(DNA_UI_BEARD2_R, 255, DNA_UI), head_organ.dna.GetDNAValue(DNA_UI_BEARD2_G, 255, DNA_UI), head_organ.dna.GetDNAValue(DNA_UI_BEARD2_B, 255, DNA_UI))
 
 	//Head Accessories
-	var/headacc = GetUIValueRange(DNA_UI_HACC_STYLE,GLOB.head_accessory_styles_list.len)
+	var/headacc = GetDNAValue(DNA_UI_HACC_STYLE, GLOB.head_accessory_styles_list.len, DNA_UI)
 	if((headacc > 0) && (headacc <= GLOB.head_accessory_styles_list.len))
 		head_organ.ha_style = GLOB.head_accessory_styles_list[headacc]
 
-	head_organ.headacc_colour = rgb(head_organ.dna.GetUIValueRange(DNA_UI_HACC_R, 255), head_organ.dna.GetUIValueRange(DNA_UI_HACC_G, 255), head_organ.dna.GetUIValueRange(DNA_UI_HACC_B, 255))
+	head_organ.headacc_colour = rgb(head_organ.dna.GetDNAValue(DNA_UI_HACC_R, 255, DNA_UI), head_organ.dna.GetDNAValue(DNA_UI_HACC_G, 255, DNA_UI), head_organ.dna.GetDNAValue(DNA_UI_HACC_B, 255, DNA_UI))
 
 // This proc gives the DNA info for eye color to the given eyes
 /datum/dna/proc/write_eyes_attributes(obj/item/organ/internal/eyes/eyes_organ)
-	eyes_organ.eye_colour = rgb(eyes_organ.dna.GetUIValueRange(DNA_UI_EYES_R, 255), eyes_organ.dna.GetUIValueRange(DNA_UI_EYES_G, 255), eyes_organ.dna.GetUIValueRange(DNA_UI_EYES_B, 255))
+	eyes_organ.eye_colour = rgb(eyes_organ.dna.GetDNAValue(DNA_UI_EYES_R, 255, DNA_UI), eyes_organ.dna.GetDNAValue(DNA_UI_EYES_G, 255, DNA_UI), eyes_organ.dna.GetDNAValue(DNA_UI_EYES_B, 255, DNA_UI))
 
 /*
 	TRAIT CHANGING PROCS
@@ -223,9 +223,9 @@
 		// In absence of eyes, possibly randomize the eye color DNA?
 		return
 
-	SetUIValueRange(DNA_UI_EYES_R,	color2R(eyes_organ.eye_colour),	255, 1)
-	SetUIValueRange(DNA_UI_EYES_G,	color2G(eyes_organ.eye_colour),	255, 1)
-	SetUIValueRange(DNA_UI_EYES_B,	color2B(eyes_organ.eye_colour),	255, 1)
+	SetDNAValueRange(DNA_UI_EYES_R,	color2R(eyes_organ.eye_colour),	255, DNA_UI, TRUE)
+	SetDNAValueRange(DNA_UI_EYES_G,	color2G(eyes_organ.eye_colour),	255, DNA_UI, TRUE)
+	SetDNAValueRange(DNA_UI_EYES_B,	color2B(eyes_organ.eye_colour),	255, DNA_UI, TRUE)
 
 /datum/dna/proc/head_traits_to_dna(obj/item/organ/external/head/head_organ)
 	if(!head_organ)
@@ -245,26 +245,26 @@
 		head_organ.ha_style = "None"
 	var/headacc	= GLOB.head_accessory_styles_list.Find(head_organ.ha_style)
 
-	SetUIValueRange(DNA_UI_HAIR_R,		color2R(head_organ.hair_colour),		255,	 1)
-	SetUIValueRange(DNA_UI_HAIR_G,		color2G(head_organ.hair_colour),		255,	 1)
-	SetUIValueRange(DNA_UI_HAIR_B,		color2B(head_organ.hair_colour),		255,	 1)
+	SetDNAValueRange(DNA_UI_HAIR_R,		color2R(head_organ.hair_colour),		255,	 DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_HAIR_G,		color2G(head_organ.hair_colour),		255,	 DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_HAIR_B,		color2B(head_organ.hair_colour),		255,	 DNA_UI,	TRUE)
 
-	SetUIValueRange(DNA_UI_HAIR2_R,		color2R(head_organ.sec_hair_colour),	255,	 1)
-	SetUIValueRange(DNA_UI_HAIR2_G,		color2G(head_organ.sec_hair_colour),	255,	 1)
-	SetUIValueRange(DNA_UI_HAIR2_B,		color2B(head_organ.sec_hair_colour),	255,	 1)
+	SetDNAValueRange(DNA_UI_HAIR2_R,		color2R(head_organ.sec_hair_colour),	255,	 DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_HAIR2_G,		color2G(head_organ.sec_hair_colour),	255,	 DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_HAIR2_B,		color2B(head_organ.sec_hair_colour),	255,	 DNA_UI,	TRUE)
 
-	SetUIValueRange(DNA_UI_BEARD_R,		color2R(head_organ.facial_colour),		255,	 1)
-	SetUIValueRange(DNA_UI_BEARD_G,		color2G(head_organ.facial_colour),		255,	 1)
-	SetUIValueRange(DNA_UI_BEARD_B,		color2B(head_organ.facial_colour),		255,	 1)
+	SetDNAValueRange(DNA_UI_BEARD_R,		color2R(head_organ.facial_colour),		255,	 DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_BEARD_G,		color2G(head_organ.facial_colour),		255,	 DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_BEARD_B,		color2B(head_organ.facial_colour),		255,	 DNA_UI,	TRUE)
 
-	SetUIValueRange(DNA_UI_BEARD2_R,	color2R(head_organ.sec_facial_colour),	255,	 1)
-	SetUIValueRange(DNA_UI_BEARD2_G,	color2G(head_organ.sec_facial_colour),	255,	 1)
-	SetUIValueRange(DNA_UI_BEARD2_B,	color2B(head_organ.sec_facial_colour),	255,	 1)
+	SetDNAValueRange(DNA_UI_BEARD2_R,	color2R(head_organ.sec_facial_colour),	255,	 DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_BEARD2_G,	color2G(head_organ.sec_facial_colour),	255,	 DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_BEARD2_B,	color2B(head_organ.sec_facial_colour),	255,	 DNA_UI,	TRUE)
 
-	SetUIValueRange(DNA_UI_HACC_R,		color2R(head_organ.headacc_colour),		255,	 1)
-	SetUIValueRange(DNA_UI_HACC_G,		color2G(head_organ.headacc_colour),		255,	 1)
-	SetUIValueRange(DNA_UI_HACC_B,		color2B(head_organ.headacc_colour),		255,	 1)
+	SetDNAValueRange(DNA_UI_HACC_R,		color2R(head_organ.headacc_colour),		255,	 DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_HACC_G,		color2G(head_organ.headacc_colour),		255,	 DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_HACC_B,		color2B(head_organ.headacc_colour),		255,	 DNA_UI,	TRUE)
 
-	SetUIValueRange(DNA_UI_HAIR_STYLE,	hair,		GLOB.hair_styles_full_list.len,		 1)
-	SetUIValueRange(DNA_UI_BEARD_STYLE,	beard,		GLOB.facial_hair_styles_list.len,	 1)
-	SetUIValueRange(DNA_UI_HACC_STYLE,	headacc,	GLOB.head_accessory_styles_list.len, 1)
+	SetDNAValueRange(DNA_UI_HAIR_STYLE,	hair,		GLOB.hair_styles_full_list.len,		 DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_BEARD_STYLE,	beard,		GLOB.facial_hair_styles_list.len,	 DNA_UI,	TRUE)
+	SetDNAValueRange(DNA_UI_HACC_STYLE,	headacc,	GLOB.head_accessory_styles_list.len, DNA_UI,	TRUE)

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -751,7 +751,7 @@
 						connected.occupant.UpdateAppearance(buf.dna.UI.Copy())
 					else if(buf.types & DNA2_BUF_SE)
 						connected.occupant.dna.SE = buf.dna.SE.Copy()
-						connected.occupant.dna.UpdateSE()
+						connected.occupant.dna.UpdateDNA(DNA_SE)
 						domutcheck(connected.occupant, connected)
 				if("createInjector")
 					if(!injector_ready)

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -571,7 +571,7 @@
 			selected_ui_block = clamp(select_block, 1, DNA_UI_LENGTH)
 			selected_ui_subblock = clamp(select_subblock, 1, DNA_BLOCK_SIZE)
 		if("pulseUIRadiation")
-			var/block = connected.occupant.dna.GetUISubBlock(selected_ui_block, selected_ui_subblock)
+			var/block = connected.occupant.dna.GetDNASubBlock(selected_ui_block, selected_ui_subblock, DNA_UI)
 
 			irradiating = radiation_duration
 			var/lock_state = connected.locked
@@ -594,7 +594,7 @@
 					return
 
 				block = miniscrambletarget(num2text(selected_ui_target), radiation_intensity, radiation_duration)
-				connected.occupant.dna.SetUISubBlock(selected_ui_block, selected_ui_subblock, block)
+				connected.occupant.dna.SetDNASubBlock(selected_ui_block, selected_ui_subblock, block, DNA_UI)
 				connected.occupant.UpdateAppearance()
 			else
 				var/radiation = ((radiation_intensity * 2) + radiation_duration)
@@ -627,7 +627,7 @@
 			selected_se_block = clamp(select_block, 1, DNA_SE_LENGTH)
 			selected_se_subblock = clamp(select_subblock, 1, DNA_BLOCK_SIZE)
 		if("pulseSERadiation")
-			var/block = connected.occupant.dna.GetSESubBlock(selected_se_block, selected_se_subblock)
+			var/block = connected.occupant.dna.GetDNASubBlock(selected_se_block, selected_se_subblock, DNA_SE)
 			//var/original_block=block
 			//testing("Irradiating SE block [selected_se_block]:[selected_se_subblock] ([block])...")
 
@@ -658,7 +658,7 @@
 							real_SE_block--
 
 					//testing("Irradiated SE block [real_SE_block]:[selected_se_subblock] ([original_block] now [block]) [(real_SE_block!=selected_se_block) ? "(SHIFTED)":""]!")
-					connected.occupant.dna.SetSESubBlock(real_SE_block, selected_se_subblock, block)
+					connected.occupant.dna.SetDNASubBlock(real_SE_block, selected_se_subblock, block, DNA_SE)
 					domutcheck(connected.occupant, connected)
 				else
 					var/radiation = (((radiation_intensity * 2) + radiation_duration) / connected.damage_coeff)

--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -176,7 +176,7 @@
 		return
 	if((HULK in M.mutations) && M.health <= 0)
 		M.mutations.Remove(HULK)
-		M.dna.SetSEState(GLOB.hulkblock,0)
+		M.dna.SetDNAState(GLOB.hulkblock, FALSE, DNA_SE)
 		genemutcheck(M, GLOB.hulkblock,null,MUTCHK_FORCED)
 		M.update_mutations()		//update our mutation overlays
 		M.update_body()

--- a/code/game/gamemodes/changeling/powers/chameleon_skin.dm
+++ b/code/game/gamemodes/changeling/powers/chameleon_skin.dm
@@ -12,10 +12,10 @@
 	if(!istype(H)) // req_human could be done in can_sting stuff.
 		return
 	if(H.dna.GetSEState(GLOB.chameleonblock))
-		H.dna.SetSEState(GLOB.chameleonblock, 0)
+		H.dna.SetSEState(GLOB.chameleonblock, FALSE)
 		genemutcheck(H, GLOB.chameleonblock, null, MUTCHK_FORCED)
 	else
-		H.dna.SetSEState(GLOB.chameleonblock, 1)
+		H.dna.SetDNAState(GLOB.chameleonblock, DNA_SE, TRUE)
 		genemutcheck(H, GLOB.chameleonblock, null, MUTCHK_FORCED)
 
 	SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]"))
@@ -24,6 +24,6 @@
 /datum/action/changeling/chameleon_skin/Remove(mob/user)
 	var/mob/living/carbon/C = user
 	if(C.dna.GetSEState(GLOB.chameleonblock))
-		C.dna.SetSEState(GLOB.chameleonblock, 0)
+		C.dna.SetSEState(GLOB.chameleonblock, FALSE)
 		genemutcheck(C, GLOB.chameleonblock, null, MUTCHK_FORCED)
 	..()

--- a/code/game/gamemodes/changeling/powers/chameleon_skin.dm
+++ b/code/game/gamemodes/changeling/powers/chameleon_skin.dm
@@ -23,7 +23,7 @@
 
 /datum/action/changeling/chameleon_skin/Remove(mob/user)
 	var/mob/living/carbon/C = user
-	if(C.dna.GetDNAState(GLOB.chameleonblock), DNA_SE)
+	if(C.dna.GetDNAState(GLOB.chameleonblock, DNA_SE))
 		C.dna.SetDNAState(GLOB.chameleonblock, FALSE, DNA_SE)
 		genemutcheck(C, GLOB.chameleonblock, null, MUTCHK_FORCED)
 	..()

--- a/code/game/gamemodes/changeling/powers/chameleon_skin.dm
+++ b/code/game/gamemodes/changeling/powers/chameleon_skin.dm
@@ -11,8 +11,8 @@
 	var/mob/living/carbon/human/H = user //SHOULD always be human, because req_human = 1
 	if(!istype(H)) // req_human could be done in can_sting stuff.
 		return
-	if(H.dna.GetSEState(GLOB.chameleonblock))
-		H.dna.SetSEState(GLOB.chameleonblock, FALSE)
+	if(H.dna.GetDNAState(GLOB.chameleonblock, DNA_SE))
+		H.dna.SetDNAState(GLOB.chameleonblock, FALSE, DNA_SE)
 		genemutcheck(H, GLOB.chameleonblock, null, MUTCHK_FORCED)
 	else
 		H.dna.SetDNAState(GLOB.chameleonblock, DNA_SE, TRUE)
@@ -23,7 +23,7 @@
 
 /datum/action/changeling/chameleon_skin/Remove(mob/user)
 	var/mob/living/carbon/C = user
-	if(C.dna.GetSEState(GLOB.chameleonblock))
-		C.dna.SetSEState(GLOB.chameleonblock, FALSE)
+	if(C.dna.GetDNAState(GLOB.chameleonblock), DNA_SE)
+		C.dna.SetDNAState(GLOB.chameleonblock, FALSE, DNA_SE)
 		genemutcheck(C, GLOB.chameleonblock, null, MUTCHK_FORCED)
 	..()

--- a/code/game/gamemodes/changeling/powers/humanform.dm
+++ b/code/game/gamemodes/changeling/powers/humanform.dm
@@ -32,8 +32,7 @@
 	user.real_name = chosen_dna.real_name
 	domutcheck(user,null,MUTCHK_FORCED)
 	user.flavor_text = ""
-	user.dna.UpdateSE()
-	user.dna.UpdateUI()
+	user.dna.UpdateDNA(DNA_ALL)
 	user.sync_organ_dna(1)
 	user.UpdateAppearance()
 

--- a/code/game/gamemodes/changeling/powers/humanform.dm
+++ b/code/game/gamemodes/changeling/powers/humanform.dm
@@ -24,7 +24,7 @@
 	if(!user)
 		return 0
 	to_chat(user, "<span class='notice'>We transform our appearance.</span>")
-	user.dna.SetSEState(GLOB.monkeyblock,0,1)
+	user.dna.SetDNAState(GLOB.monkeyblock, FALSE, DNA_SE, TRUE)
 	genemutcheck(user,GLOB.monkeyblock,null,MUTCHK_FORCED)
 	if(istype(user))
 		user.set_species(chosen_dna.species.type)

--- a/code/game/gamemodes/devil/devilinfo.dm
+++ b/code/game/gamemodes/devil/devilinfo.dm
@@ -476,8 +476,7 @@ GLOBAL_LIST_INIT(lawlorify, list (
 			H.set_species(humanform.species)
 			H.dna = humanform.Clone()
 
-			H.dna.UpdateSE()
-			H.dna.UpdateUI()
+			H.UpdateDNA(DNA_ALL)
 
 			H.sync_organ_dna(1) // It's literally a fresh body as you can get, so all organs properly belong to it
 			H.UpdateAppearance()

--- a/code/game/gamemodes/devil/devilinfo.dm
+++ b/code/game/gamemodes/devil/devilinfo.dm
@@ -476,7 +476,7 @@ GLOBAL_LIST_INIT(lawlorify, list (
 			H.set_species(humanform.species)
 			H.dna = humanform.Clone()
 
-			H.UpdateDNA(DNA_ALL)
+			H.dna.UpdateDNA(DNA_ALL)
 
 			H.sync_organ_dna(1) // It's literally a fresh body as you can get, so all organs properly belong to it
 			H.UpdateAppearance()

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -286,7 +286,7 @@
 /obj/item/organ/internal/heart/gland/electric/remove(mob/living/carbon/M, special = 0)
 	if(ishuman(owner))
 		owner.gene_stability -= GENE_INSTABILITY_MODERATE // but return it to normal once it's removed
-		owner.dna.SetSEState(GLOB.shockimmunityblock, FALSE)
+		owner.dna.SetDNAState(GLOB.shockimmunityblock, FALSE, DNA_SE)
 		genemutcheck(owner, GLOB.shockimmunityblock,  null, MUTCHK_FORCED)
 	return ..()
 

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -280,7 +280,7 @@
 	..()
 	if(ishuman(owner))
 		owner.gene_stability += GENE_INSTABILITY_MODERATE // give them this gene for free
-		owner.dna.SetSEState(GLOB.shockimmunityblock, TRUE)
+		owner.dna.SetDNAState(GLOB.shockimmunityblock, DNA_SE, TRUE)
 		genemutcheck(owner, GLOB.shockimmunityblock,  null, MUTCHK_FORCED)
 
 /obj/item/organ/internal/heart/gland/electric/remove(mob/living/carbon/M, special = 0)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -246,7 +246,7 @@
 		H.update_body()
 		H.reset_hair() //No more winding up with hairstyles you're not supposed to have, and blowing your cover.
 		H.reset_markings() //...Or markings.
-		H.dna.ResetUIFrom(H)
+		H.dna.ResetDNAFrom(H, DNA_UI)
 		H.flavor_text = ""
 	user.update_icons()
 

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -155,7 +155,7 @@
 	if(visualsOnly)
 		return
 
-	H.dna.SetSEState(GLOB.soberblock,1)
+	H.dna.SetDNAState(GLOB.soberblock, TRUE, DNA_SE)
 	H.mutations += SOBER
 	H.check_mutations = 1
 

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -370,11 +370,11 @@
 		var/obj/item/organ/internal/cyberimp/brain/clown_voice/implant = new
 		implant.insert(H)
 
-	H.dna.SetSEState(GLOB.clumsyblock, TRUE)
+	H.dna.SetDNAState(GLOB.clumsyblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.clumsyblock, null, MUTCHK_FORCED)
 	H.dna.default_blocks.Add(GLOB.clumsyblock)
 	if(!ismachineperson(H))
-		H.dna.SetSEState(GLOB.comicblock, TRUE)
+		H.dna.SetDNAState(GLOB.comicblock, DNA_SE, TRUE)
 		genemutcheck(H, GLOB.comicblock, null, MUTCHK_FORCED)
 		H.dna.default_blocks.Add(GLOB.comicblock)
 	H.check_mutations = TRUE

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -34,7 +34,7 @@
 	if(visualsOnly)
 		return
 
-	H.dna.SetSEState(GLOB.soberblock,1)
+	H.dna.SetDNAState(GLOB.soberblock, TRUE, DNA_SE)
 	genemutcheck(H, GLOB.soberblock, null, MUTCHK_FORCED)
 	H.dna.default_blocks.Add(GLOB.soberblock)
 	H.check_mutations = 1

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -165,7 +165,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	for(var/i=new_SE.len;i<=DNA_SE_LENGTH;i++)
 		new_SE += rand(1,1024)
 	buf.dna.SE=new_SE
-	buf.dna.SetSEValueRange(GLOB.monkeyblock,0xDAC, 0xFFF)
+	buf.dna.SetDNAValueRange(GLOB.monkeyblock, 0xDAC, 0xFFF, DNA_SE)
 
 //Disk stuff.
 /obj/item/disk/data/New()

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -283,7 +283,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	if(efficiency < 3 && prob(50))
 		randmutb(H)
 
-	H.UpdateDNA(DNA_ALL)
+	H.dna.UpdateDNA(DNA_ALL)
 
 	H.sync_organ_dna(1) // It's literally a fresh body as you can get, so all organs properly belong to it
 	H.UpdateAppearance()

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -150,7 +150,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	if(buf.dna.UI.len != DNA_UI_LENGTH) //If there's a disparity b/w the dna UI string lengths, 0-fill the extra blocks in this UI.
 		for(var/i in buf.dna.UI.len to DNA_UI_LENGTH)
 			buf.dna.UI += 0x000
-	buf.dna.ResetSE()
+	buf.dna.ResetDNA(DNA_SE)
 	buf.dna.UpdateDNA(DNA_UI)
 
 /obj/item/disk/data/monkey

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -151,7 +151,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 		for(var/i in buf.dna.UI.len to DNA_UI_LENGTH)
 			buf.dna.UI += 0x000
 	buf.dna.ResetSE()
-	buf.dna.UpdateUI()
+	buf.dna.UpdateDNA(DNA_UI)
 
 /obj/item/disk/data/monkey
 	name = "data disk - 'Mr. Muggles'"
@@ -283,8 +283,7 @@ GLOBAL_LIST_INIT(cloner_biomass_items, list(\
 	if(efficiency < 3 && prob(50))
 		randmutb(H)
 
-	H.dna.UpdateSE()
-	H.dna.UpdateUI()
+	H.UpdateDNA(DNA_ALL)
 
 	H.sync_organ_dna(1) // It's literally a fresh body as you can get, so all organs properly belong to it
 	H.UpdateAppearance()

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -288,7 +288,7 @@
 	H.sync_organ_dna(assimilate = 1)
 	H.update_body()
 	H.reset_hair()
-	H.dna.ResetUIFrom(H)
+	H.dna.ResetDNAFrom(H, DNA_UI)
 
 
 /obj/machinery/transformer/gene_applier

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -25,7 +25,7 @@
 		buf = new
 		buf.dna = new
 		buf.types = datatype
-		buf.dna.ResetSE()
+		buf.dna.ResetDNA(DNA_SE)
 		SetValue(value)
 
 /obj/item/dnainjector/Destroy()

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -86,7 +86,7 @@
 			if(buf.types & DNA2_BUF_UI)
 				if(!block) //isolated block?
 					M.dna.UI = buf.dna.UI.Copy()
-					M.dna.UpdateUI()
+					M.dna.UpdateDNA(DNA_UI)
 					M.UpdateAppearance()
 					if(buf.types & DNA2_BUF_UE) //unique enzymes? yes
 
@@ -100,7 +100,7 @@
 			if(buf.types & DNA2_BUF_SE)
 				if(!block) //isolated block?
 					M.dna.SE = buf.dna.SE.Copy()
-					M.dna.UpdateSE()
+					M.dna.UpdateDNA(DNA_SE)
 				else
 					M.dna.SetSEValue(block,src.GetValue())
 				domutcheck(M, null, forcedmutation ? MUTCHK_FORCED : 0)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -95,14 +95,14 @@
 						M.dna.real_name = buf.dna.real_name
 						M.dna.unique_enzymes = buf.dna.unique_enzymes
 				else
-					M.dna.SetUIValue(block,src.GetValue())
+					M.dna.SetDNAValue(block, GetValue(), DNA_UI)
 					M.UpdateAppearance()
 			if(buf.types & DNA2_BUF_SE)
 				if(!block) //isolated block?
 					M.dna.SE = buf.dna.SE.Copy()
 					M.dna.UpdateDNA(DNA_SE)
 				else
-					M.dna.SetSEValue(block,src.GetValue())
+					M.dna.SetDNAValue(block, GetValue(), DNA_SE)
 				domutcheck(M, null, forcedmutation ? MUTCHK_FORCED : 0)
 				M.update_mutations()
 			if(H)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -41,30 +41,30 @@
 /obj/item/dnainjector/proc/GetState(selblock = 0)
 	var/real_block = GetRealBlock(selblock)
 	if(buf.types & DNA2_BUF_SE)
-		return buf.dna.GetSEState(real_block)
+		return buf.dna.GetDNAState(real_block, DNA_SE)
 	else
-		return buf.dna.GetUIState(real_block)
+		return buf.dna.GetDNAState(real_block, DNA_UI)
 
 /obj/item/dnainjector/proc/SetState(on, selblock = 0)
 	var/real_block = GetRealBlock(selblock)
 	if(buf.types & DNA2_BUF_SE)
-		return buf.dna.SetSEState(real_block,on)
+		return buf.dna.SetDNAState(real_block, on, DNA_SE)
 	else
-		return buf.dna.SetUIState(real_block,on)
+		return buf.dna.SetDNAState(real_block, on, DNA_UI)
 
 /obj/item/dnainjector/proc/GetValue(selblock = 0)
 	var/real_block = GetRealBlock(selblock)
 	if(buf.types & DNA2_BUF_SE)
-		return buf.dna.GetSEValue(real_block)
+		return buf.dna.GetDNAValue(real_block, DNA_SE)
 	else
-		return buf.dna.GetUIValue(real_block)
+		return buf.dna.GetDNAValue(real_block, DNA_UI)
 
 /obj/item/dnainjector/proc/SetValue(val, selblock = 0)
 	var/real_block = GetRealBlock(selblock)
 	if(buf.types & DNA2_BUF_SE)
-		return buf.dna.SetSEValue(real_block,val)
+		return buf.dna.SetDNAValue(real_block, val, DNA_SE)
 	else
-		return buf.dna.SetUIValue(real_block,val)
+		return buf.dna.SetDNAValue(real_block, val, DNA_UI)
 
 /obj/item/dnainjector/proc/inject(mob/living/M, mob/user)
 	if(used)

--- a/code/game/objects/items/weapons/dnascrambler.dm
+++ b/code/game/objects/items/weapons/dnascrambler.dm
@@ -48,7 +48,7 @@
 		H.update_body()
 		H.reset_hair() //No more winding up with hairstyles you're not supposed to have, and blowing your cover.
 		H.reset_markings() //...Or markings.
-		H.dna.ResetUIFrom(H)
+		H.dna.ResetDNAFrom(H, DNA_UI)
 		H.flavor_text = ""
 	target.update_icons()
 

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -145,11 +145,11 @@
 				if("Mute")
 					voice_mutation = GLOB.muteblock
 			if(voice_mutation)
-				if(H.dna.GetSEState(voice_mutation))
-					H.dna.SetSEState(voice_mutation, FALSE)
+				if(H.dna.GetDNAState(voice_mutation, DNA_SE))
+					H.dna.SetDNAState(voice_mutation, FALSE, DNA_SE)
 					genemutcheck(H, voice_mutation, null, MUTCHK_FORCED)
 				else
-					H.dna.SetDNAState(voice_mutation, DNA_SE, TRUE)
+					H.dna.SetDNAState(voice_mutation, TRUE, DNA_SE)
 					genemutcheck(H, voice_mutation, null, MUTCHK_FORCED)
 
 			if(voice_choice)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -149,7 +149,7 @@
 					H.dna.SetSEState(voice_mutation, FALSE)
 					genemutcheck(H, voice_mutation, null, MUTCHK_FORCED)
 				else
-					H.dna.SetSEState(voice_mutation, TRUE)
+					H.dna.SetDNAState(voice_mutation, DNA_SE, TRUE)
 					genemutcheck(H, voice_mutation, null, MUTCHK_FORCED)
 
 			if(voice_choice)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -227,7 +227,7 @@ GLOBAL_VAR_INIT(nologevent, 0)
 					bname = GLOB.assigned_blocks[block]
 					body += "<td>"
 					if(bname)
-						var/bstate=M.dna.GetSEState(block)
+						var/bstate=M.dna.GetDNAState(block, DNA_SE)
 						var/bcolor="[(bstate)?"#006600":"#ff0000"]"
 						body += "<A href='?_src_=holder;togmutate=[M.UID()];block=[block]' style='color:[bcolor];'>[bname]</A><sub>[block]</sub>"
 					else

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2015,7 +2015,7 @@
 				H.reagents.add_reagent("spaceacillin", 20)
 				logmsg = "a heal over time."
 			if("Permanent Regeneration")
-				H.dna.SetSEState(GLOB.regenerateblock, 1)
+				H.dna.SetDNAState(GLOB.regenerateblock, DNA_SE, TRUE)
 				genemutcheck(H, GLOB.regenerateblock,  null, MUTCHK_FORCED)
 				H.update_mutations()
 				H.gene_stability = 100
@@ -2023,7 +2023,7 @@
 			if("Super Powers")
 				var/list/default_genes = list(GLOB.regenerateblock, GLOB.breathlessblock, GLOB.coldblock)
 				for(var/gene in default_genes)
-					H.dna.SetSEState(gene, 1)
+					H.dna.SetDNAState(gene, DNA_SE, TRUE)
 					genemutcheck(H, gene,  null, MUTCHK_FORCED)
 					H.update_mutations()
 				H.gene_stability = 100

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -853,7 +853,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 		alert("Wait until the game starts")
 		return
 	if(istype(M, /mob/living/carbon))
-		M.dna.SetSEState(block,!M.dna.GetSEState(block))
+		M.dna.SetDNAState(block, !M.dna.GetDNAState(block, DNA_SE), DNA_SE)
 		genemutcheck(M,block,null,MUTCHK_FORCED)
 		M.update_mutations()
 		var/state="[M.dna.GetSEState(block)?"on":"off"]"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -856,7 +856,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 		M.dna.SetDNAState(block, !M.dna.GetDNAState(block, DNA_SE), DNA_SE)
 		genemutcheck(M,block,null,MUTCHK_FORCED)
 		M.update_mutations()
-		var/state="[M.dna.GetSEState(block)?"on":"off"]"
+		var/state="[M.dna.GetDNAState(block, DNA_SE)?"on":"off"]"
 		var/blockname=GLOB.assigned_blocks[block]
 		message_admins("[key_name_admin(src)] has toggled [M.key]'s [blockname] block [state]!")
 		log_admin("[key_name(src)] has toggled [M.key]'s [blockname] block [state]!")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -424,7 +424,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		var/list/newSE= record_found.fields["enzymes"]
 		var/list/newUI = record_found.fields["identity"]
 		new_character.dna.SE = newSE.Copy() //This is the default of enzymes so I think it's safe to go with.
-		new_character.dna.UpdateSE()
+		new_character.dna.UpdateDNA(DNA_SE)
 		new_character.UpdateAppearance(newUI.Copy())//Now we configure their appearance based on their unique identity, same as with a DNA machine or somesuch.
 	else//If they have no records, we just do a random DNA for them, based on their random appearance/savefile.
 		new_character.dna.ready_dna(new_character)

--- a/code/modules/antagonists/wishgranter/wishgranter.dm
+++ b/code/modules/antagonists/wishgranter/wishgranter.dm
@@ -22,55 +22,55 @@
 	if(!istype(H))
 		return
 	H.ignore_gene_stability = TRUE
-	H.dna.SetSEState(GLOB.hulkblock, TRUE)
+	H.dna.SetDNAState(GLOB.hulkblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.hulkblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.xrayblock, TRUE)
+	H.dna.SetDNAState(GLOB.xrayblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.xrayblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.fireblock, TRUE)
+	H.dna.SetDNAState(GLOB.fireblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.fireblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.coldblock, TRUE)
+	H.dna.SetDNAState(GLOB.coldblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.coldblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.teleblock, TRUE)
+	H.dna.SetDNAState(GLOB.teleblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.teleblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.increaserunblock, TRUE)
+	H.dna.SetDNAState(GLOB.increaserunblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.increaserunblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.breathlessblock, TRUE)
+	H.dna.SetDNAState(GLOB.breathlessblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.breathlessblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.regenerateblock, TRUE)
+	H.dna.SetDNAState(GLOB.regenerateblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.regenerateblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.shockimmunityblock, TRUE)
+	H.dna.SetDNAState(GLOB.shockimmunityblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.shockimmunityblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.smallsizeblock, TRUE)
+	H.dna.SetDNAState(GLOB.smallsizeblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.smallsizeblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.soberblock, TRUE)
+	H.dna.SetDNAState(GLOB.soberblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.soberblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.psyresistblock, TRUE)
+	H.dna.SetDNAState(GLOB.psyresistblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.psyresistblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.shadowblock, TRUE)
+	H.dna.SetDNAState(GLOB.shadowblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.shadowblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.cryoblock, TRUE)
+	H.dna.SetDNAState(GLOB.cryoblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.cryoblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.eatblock, TRUE)
+	H.dna.SetDNAState(GLOB.eatblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.eatblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.jumpblock, TRUE)
+	H.dna.SetDNAState(GLOB.jumpblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.jumpblock, null, MUTCHK_FORCED)
 
-	H.dna.SetSEState(GLOB.immolateblock, TRUE)
+	H.dna.SetDNAState(GLOB.immolateblock, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.immolateblock, null, MUTCHK_FORCED)
 
 	H.mutations.Add(LASER)

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -2311,7 +2311,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 	character.dna.species.handle_dna(character)
 
 	if(character.dna.dirtySE)
-		character.dna.UpdateSE()
+		character.dna.UpdateDNA(DNA_SE)
 	domutcheck(character, null, MUTCHK_FORCED) //'Activates' all the above disabilities.
 
 	character.dna.ready_dna(character, flatten_SE = 0)

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -2260,52 +2260,52 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 	character.original_eye_color = e_colour
 
 	if(disabilities & DISABILITY_FLAG_FAT)
-		character.dna.SetSEState(GLOB.fatblock, TRUE, TRUE)
+		character.dna.SetDNAState(GLOB.fatblock, TRUE, DNA_SE, TRUE)
 		character.overeatduration = 600
 		character.dna.default_blocks.Add(GLOB.fatblock)
 
 	if(disabilities & DISABILITY_FLAG_NEARSIGHTED)
-		character.dna.SetSEState(GLOB.glassesblock, TRUE, TRUE)
+		character.dna.SetDNAState(GLOB.glassesblock, TRUE, DNA_SE, TRUE)
 		character.dna.default_blocks.Add(GLOB.glassesblock)
 
 	if(disabilities & DISABILITY_FLAG_BLIND)
-		character.dna.SetSEState(GLOB.blindblock, TRUE, TRUE)
+		character.dna.SetDNAState(GLOB.blindblock, TRUE, DNA_SE, TRUE)
 		character.dna.default_blocks.Add(GLOB.blindblock)
 
 	if(disabilities & DISABILITY_FLAG_DEAF)
-		character.dna.SetSEState(GLOB.deafblock, TRUE, TRUE)
+		character.dna.SetDNAState(GLOB.deafblock, TRUE, DNA_SE, TRUE)
 		character.dna.default_blocks.Add(GLOB.deafblock)
 
 	if(disabilities & DISABILITY_FLAG_COLOURBLIND)
-		character.dna.SetSEState(GLOB.colourblindblock, TRUE, TRUE)
+		character.dna.SetDNAState(GLOB.colourblindblock, TRUE, DNA_SE, TRUE)
 		character.dna.default_blocks.Add(GLOB.colourblindblock)
 
 	if(disabilities & DISABILITY_FLAG_MUTE)
-		character.dna.SetSEState(GLOB.muteblock, TRUE, TRUE)
+		character.dna.SetDNAState(GLOB.muteblock, TRUE, DNA_SE, TRUE)
 		character.dna.default_blocks.Add(GLOB.muteblock)
 
 	if(disabilities & DISABILITY_FLAG_NERVOUS)
-		character.dna.SetSEState(GLOB.nervousblock, TRUE, TRUE)
+		character.dna.SetDNAState(GLOB.nervousblock, TRUE, DNA_SE, TRUE)
 		character.dna.default_blocks.Add(GLOB.nervousblock)
 
 	if(disabilities & DISABILITY_FLAG_SWEDISH)
-		character.dna.SetSEState(GLOB.swedeblock, TRUE, TRUE)
+		character.dna.SetDNAState(GLOB.swedeblock, TRUE, DNA_SE, TRUE)
 		character.dna.default_blocks.Add(GLOB.swedeblock)
 
 	if(disabilities & DISABILITY_FLAG_CHAV)
-		character.dna.SetSEState(GLOB.chavblock, TRUE, TRUE)
+		character.dna.SetDNAState(GLOB.chavblock, TRUE, DNA_SE, TRUE)
 		character.dna.default_blocks.Add(GLOB.chavblock)
 
 	if(disabilities & DISABILITY_FLAG_LISP)
-		character.dna.SetSEState(GLOB.lispblock, TRUE, TRUE)
+		character.dna.SetDNAState(GLOB.lispblock, TRUE, DNA_SE, TRUE)
 		character.dna.default_blocks.Add(GLOB.lispblock)
 
 	if(disabilities & DISABILITY_FLAG_DIZZY)
-		character.dna.SetSEState(GLOB.dizzyblock, TRUE, TRUE)
+		character.dna.SetDNAState(GLOB.dizzyblock, TRUE, DNA_SE, TRUE)
 		character.dna.default_blocks.Add(GLOB.dizzyblock)
 
 	if(disabilities & DISABILITY_FLAG_WINGDINGS && (CAN_WINGDINGS in character.dna.species.species_traits))
-		character.dna.SetSEState(GLOB.wingdingsblock, TRUE, TRUE)
+		character.dna.SetDNAState(GLOB.wingdingsblock, TRUE, DNA_SE, TRUE)
 		character.dna.default_blocks.Add(GLOB.wingdingsblock)
 
 	character.dna.species.handle_dna(character)

--- a/code/modules/mob/living/carbon/brain/robotic_brain.dm
+++ b/code/modules/mob/living/carbon/brain/robotic_brain.dm
@@ -207,8 +207,7 @@
 	brainmob.SetSilence(0)
 	brainmob.dna = new(brainmob)
 	brainmob.dna.species = new /datum/species/machine() // Else it will default to human. And we don't want to clone IRC humans now do we?
-	brainmob.dna.ResetSE()
-	brainmob.dna.ResetUI()
+	brainmob.dna.ResetDNA(DNA_ALL)
 	GLOB.dead_mob_list -= brainmob
 	..()
 

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -473,4 +473,4 @@
 	update_body()
 	reset_hair() //No more winding up with hairstyles you're not supposed to have, and blowing your cover.
 	reset_markings() //...Or markings.
-	dna.ResetUIFrom(src)
+	dna.ResetDNAFrom(src, DNA_UI)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1964,7 +1964,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	update_icons()
 /mob/living/carbon/human/proc/cleanSE()	//remove all disabilities/powers
 	for(var/block = 1; block <= DNA_SE_LENGTH; block++)
-		dna.SetSEState(block, FALSE, TRUE)
+		dna.SetDNAState(block, FALSE, DNA_SE, TRUE)
 		genemutcheck(src, block, null, MUTCHK_FORCED)
 	dna.UpdateDNA(DNA_SE)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1234,8 +1234,7 @@
 	domutcheck(src, null, MUTCHK_FORCED) //Ensures species that get powers by the species proc handle_dna keep them
 	if(!keep_flavor_text)
 		flavor_text = ""
-	dna.UpdateSE()
-	dna.UpdateUI()
+	dna.UpdateDNA(DNA_ALL)
 	sync_organ_dna(TRUE)
 	UpdateAppearance()
 	sec_hud_set_ID()
@@ -1967,7 +1966,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	for(var/block = 1; block <= DNA_SE_LENGTH; block++)
 		dna.SetSEState(block, FALSE, TRUE)
 		genemutcheck(src, block, null, MUTCHK_FORCED)
-	dna.UpdateSE()
+	dna.UpdateDNA(DNA_SE)
 
 /mob/living/carbon/human/get_spooked()
 	to_chat(src, "<span class='whisper'>[pick(GLOB.boo_phrases)]</span>")

--- a/code/modules/mob/living/carbon/human/species/drask.dm
+++ b/code/modules/mob/living/carbon/human/species/drask.dm
@@ -66,7 +66,7 @@
 
 /datum/species/drask/handle_dna(mob/living/carbon/human/H, remove)
 	..()
-	H.dna.SetSEState(GLOB.strongblock, !remove, 1)
+	H.dna.SetDNAState(GLOB.strongblock, !remove, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.strongblock, null, MUTCHK_FORCED)
 	H.dna.default_blocks.Add(GLOB.strongblock)
 

--- a/code/modules/mob/living/carbon/human/species/grey.dm
+++ b/code/modules/mob/living/carbon/human/species/grey.dm
@@ -32,7 +32,7 @@
 
 /datum/species/grey/handle_dna(mob/living/carbon/human/H, remove)
 	..()
-	H.dna.SetSEState(GLOB.remotetalkblock, !remove, 1)
+	H.dna.SetDNAState(GLOB.remotetalkblock, !remove, DNA_SE, TRUE)
 	genemutcheck(H, GLOB.remotetalkblock, null, MUTCHK_FORCED)
 	H.dna.default_blocks.Add(GLOB.remotetalkblock)
 

--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -58,7 +58,7 @@
 /datum/species/monkey/handle_dna(mob/living/carbon/human/H, remove)
 	..()
 	if(!remove)
-		H.dna.SetSEState(GLOB.monkeyblock, TRUE)
+		H.dna.SetDNAState(GLOB.monkeyblock, DNA_SE, TRUE)
 		genemutcheck(H, GLOB.monkeyblock, null, MUTCHK_FORCED)
 
 /datum/species/monkey/tajaran

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1301,7 +1301,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	var/husk = (HUSK in mutations)
 	var/hulk = (HULK in mutations)
 	var/skeleton = (SKELETON in mutations)
-	var/g = dna.GetUITriState(DNA_UI_GENDER)
+	var/g = dna.GetDNATriState(DNA_UI_GENDER, DNA_UI)
 	if(g == DNA_GENDER_PLURAL)
 		g = DNA_GENDER_FEMALE
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1332,7 +1332,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		if(part)
 			var/datum/species/S = GLOB.all_species[part.dna.species.name]
 			. += "[S.race_key]"
-			. += "[part.dna.GetUIValue(DNA_UI_SKIN_TONE)]"
+			. += "[part.dna.GetDNAValue(DNA_UI_SKIN_TONE, DNA_UI)]"
 			. += "[g]"
 			if(part.s_col)
 				. += "[part.s_col]"

--- a/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
@@ -328,7 +328,7 @@
 
 /obj/effect/mob_spawn/human/corpse/damaged/legioninfested/dwarf/equip(mob/living/carbon/human/H)
 	. = ..()
-	H.dna.SetSEState(GLOB.smallsizeblock, 1, 1)
+	H.dna.SetDNAState(GLOB.smallsizeblock, TRUE, DNA_SE, TRUE)
 	H.mutations.Add(DWARF)
 	genemutcheck(H, GLOB.smallsizeblock, null, MUTCHK_FORCED)
 	H.update_mutations()

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -543,7 +543,7 @@
 
 /mob/living/proc/CureIfHasDisability(block)
 	if(dna && dna.GetSEState(block))
-		dna.SetSEState(block, 0, 1) //Fix the gene
+		dna.SetDNAState(block, FALSE, DNA_SE, TRUE) //Fix the gene
 		genemutcheck(src, block,null, MUTCHK_FORCED)
 		dna.UpdateDNA(DNA_SE)
 

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -545,7 +545,7 @@
 	if(dna && dna.GetSEState(block))
 		dna.SetSEState(block, 0, 1) //Fix the gene
 		genemutcheck(src, block,null, MUTCHK_FORCED)
-		dna.UpdateSE()
+		dna.UpdateDNA(DNA_SE)
 
 ///////////////////////////////// FROZEN /////////////////////////////////////
 

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -542,7 +542,7 @@
 	CureIfHasDisability(GLOB.twitchblock)
 
 /mob/living/proc/CureIfHasDisability(block)
-	if(dna && dna.GetSEState(block))
+	if(dna && dna.GetDNAState(block, DNA_SE))
 		dna.SetDNAState(block, FALSE, DNA_SE, TRUE) //Fix the gene
 		genemutcheck(src, block,null, MUTCHK_FORCED)
 		dna.UpdateDNA(DNA_SE)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/human/proc/monkeyize()
 	var/mob/H = src
-	H.dna.SetSEState(GLOB.monkeyblock,1)
+	H.dna.SetDNAState(GLOB.monkeyblock, TRUE, DNA_SE)
 	genemutcheck(H,GLOB.monkeyblock,null,MUTCHK_FORCED)
 
 /mob/new_player/AIize()

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -265,7 +265,7 @@
 /obj/item/paper/contract/infernal/power/FulfillContract(mob/living/carbon/human/user = target.current, blood = 0)
 	if(!user.dna)
 		return -1
-	user.dna.SetSEState(GLOB.hulkblock,1)
+	user.dna.SetDNAState(GLOB.hulkblock, TRUE, DNA_SE)
 	genemutcheck(user, GLOB.hulkblock,null,MUTCHK_FORCED)
 	// Demonic power gives you consequenceless hulk
 	user.gene_stability += GENE_INSTABILITY_MAJOR

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -827,7 +827,7 @@
 			if(!(block in M.dna.default_blocks))
 				M.dna.SetSEState(block, FALSE, TRUE)
 				genemutcheck(M, block, null, MUTCHK_FORCED)
-		M.dna.UpdateSE()
+		M.dna.UpdateDNA(DNA_SE)
 
 		M.dna.struc_enzymes = M.dna.struc_enzymes_original
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -825,7 +825,7 @@
 	if(needs_update)
 		for(var/block = 1; block<=DNA_SE_LENGTH; block++)
 			if(!(block in M.dna.default_blocks))
-				M.dna.SetSEState(block, FALSE, TRUE)
+				M.dna.SetDNAState(block, FALSE, DNA_SE, TRUE)
 				genemutcheck(M, block, null, MUTCHK_FORCED)
 		M.dna.UpdateDNA(DNA_SE)
 

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -46,7 +46,7 @@
 
 	if(!(COLOURBLIND in M.mutations) && (COLOURBLIND in dependent_disabilities)) //If the eyes are colourblind and we're not, carry over the gene.
 		dependent_disabilities -= COLOURBLIND
-		M.dna.SetSEState(GLOB.colourblindblock,1)
+		M.dna.SetDNAState(GLOB.colourblindblock, TRUE, DNA_SE)
 		genemutcheck(M,GLOB.colourblindblock,null,MUTCHK_FORCED)
 	else
 		M.update_client_colour() //If we're here, that means the mob acquired the colourblindness gene while they didn't have eyes. Better handle it.
@@ -55,7 +55,7 @@
 	if(!special && (COLOURBLIND in M.mutations)) //If special is set, that means these eyes are getting deleted (i.e. during set_species())
 		if(!(COLOURBLIND in dependent_disabilities)) //We only want to change COLOURBLINDBLOCK and such it the eyes are being surgically removed.
 			dependent_disabilities |= COLOURBLIND
-		M.dna.SetSEState(GLOB.colourblindblock,0)
+		M.dna.SetDNAState(GLOB.colourblindblock, FALSE, DNA_SE)
 		genemutcheck(M,GLOB.colourblindblock,null,MUTCHK_FORCED)
 	. = ..()
 

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -162,7 +162,7 @@ GLOBAL_LIST_EMPTY(limb_icon_cache)
 		new_icon_state = "[icon_name][gendered_icon ? "_f" : ""]"
 	else
 		if(gendered_icon)
-			switch(dna.GetUITriState(DNA_UI_GENDER))
+			switch(dna.GetDNATriState(DNA_UI_GENDER, DNA_UI))
 				if(DNA_GENDER_FEMALE)
 					gender = "f"
 				if(DNA_GENDER_MALE)

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -46,12 +46,12 @@ GLOBAL_LIST_EMPTY(limb_icon_cache)
 /obj/item/organ/external/proc/sync_colour_to_dna()
 	if(is_robotic())
 		return
-	if(!isnull(dna.GetUIValue(DNA_UI_SKIN_TONE)) && ((dna.species.bodyflags & HAS_SKIN_TONE) || (dna.species.bodyflags & HAS_ICON_SKIN_TONE)))
+	if(!isnull(dna.GetDNAValue(DNA_UI_SKIN_TONE, DNA_UI)) && ((dna.species.bodyflags & HAS_SKIN_TONE) || (dna.species.bodyflags & HAS_ICON_SKIN_TONE)))
 		s_col = null
-		s_tone = dna.GetUIValue(DNA_UI_SKIN_TONE)
+		s_tone = dna.GetDNAValue(DNA_UI_SKIN_TONE, DNA_UI)
 	if(dna.species.bodyflags & HAS_SKIN_COLOR)
 		s_tone = null
-		s_col = rgb(dna.GetUIValue(DNA_UI_SKIN_R), dna.GetUIValue(DNA_UI_SKIN_G), dna.GetUIValue(DNA_UI_SKIN_B))
+		s_col = rgb(dna.GetDNAValue(DNA_UI_SKIN_R, DNA_UI), dna.GetDNAValue(DNA_UI_SKIN_G, DNA_UI), dna.GetDNAValue(DNA_UI_SKIN_B, DNA_UI))
 
 /obj/item/organ/external/head/sync_colour_to_human(var/mob/living/carbon/human/H)
 	..()

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -241,8 +241,8 @@
 	..()
 	M.mutations.Add(CLUMSY)
 	M.mutations.Add(GLOB.comicblock)
-	M.dna.SetSEState(GLOB.clumsyblock,1,1)
-	M.dna.SetSEState(GLOB.comicblock,1,1)
+	M.dna.SetDNAState(GLOB.clumsyblock,TRUE, DNA_SE, TRUE)
+	M.dna.SetDNAState(GLOB.comicblock,TRUE, DNA_SE, TRUE)
 	genemutcheck(M,GLOB.clumsyblock,null,MUTCHK_FORCED)
 	genemutcheck(M,GLOB.comicblock,null,MUTCHK_FORCED)
 	organhonked = world.time
@@ -254,8 +254,8 @@
 
 	M.mutations.Remove(CLUMSY)
 	M.mutations.Remove(GLOB.comicblock)
-	M.dna.SetSEState(GLOB.clumsyblock,0)
-	M.dna.SetSEState(GLOB.comicblock,0)
+	M.dna.SetDNAState(GLOB.clumsyblock, FALSE, DNA_SE)
+	M.dna.SetDNAState(GLOB.comicblock, FALSE, DNA_SE)
 	genemutcheck(M,GLOB.clumsyblock,null,MUTCHK_FORCED)
 	genemutcheck(M,GLOB.comicblock,null,MUTCHK_FORCED)
 	M.RemoveElement(/datum/element/waddling)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
What it says in the title.
This PR standardizes the code for the DNA procs. The procs for SE and the procs for UI have always been copy/pastas of each other - some with small differences, others exactly the same, some with the _comments above them_ exactly the same (one comment for an SE proc said "don't use this, use this UI proc", revealing the copy/pasta truth!).
These procs have been combined now.

Also adds new TYPE of DNA (RP) - this is easy to remove if other servers want to use this code! Additionally, it isn't fully implemented. 

## Why It's Good For The Game

1. Code Standardization = Good
2. Makes it easy to add new types of DNA. 
3. Relevant to Issue: https://github.com/ScorpioStation/ScorpioStation/issues/274 Relevant for Steps 2 & 3 of PR: https://github.com/ScorpioStation/ScorpioStation/issues/274
4. 27 procs reduced to **15 procs**
5. Replaced code block used repeatedly with proc called `ValidCheck()` 

## New Proc Syntax
**As `defer` is an optional argument, it was kept at the end.**
- UpdateDNA(dna_type) ---> *Accepts DNA_ALL*
- ResetDNA(dna_type, defer = FALSE) ---> *Accepts DNA_ALL*
- ResetDNAFrom(mob/living/carbon/human/character, dna_type) --> *Previously there was only ResetUIFrom(), so anything other than DNA_UI returns.*
=
- SetDNAState(block, on, dna_type, defer = FALSE)
- GetDNAState(block, dna_type)
- SetDNATriState(block, value, dna_type, defer = FALSE)
- GetDNATriState(block, dna_type)
=
- SetDNABlock(block, newBlock, dna_type, defer = FALSE)
- GetDNABlock(block, dna_type)
- SetDNASubBlock(block, subBlock, newSubBlock, dna_type, defer = FALSE)
- GetDNASubBlock(block, subBlock, dna_type)
=
- SetDNAValue(block, value, dna_type, defer = FALSE)
- GetDNAValue(block, dna_type)
- SetDNAValueRange(block, value, maxvalue, dna_type, defer = FALSE)
- GetDNAValueRange(block, maxvalue, dna_type)

## Changelog
:cl:
add: New DNA Type - DNA.RP to be used for Roleplaying Preferences (RP)
tweak: Code for DNA
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
