### PR TITLE
Safety First: Toy Double E-Sword

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -223,19 +223,19 @@
 	if(!wielded)
 		return
 	if(HULK in user.mutations)
-		to_chat(user, "<span class='warning'>You grip the [name] too hard and accidentally close it!</span>")
+		to_chat(user, "<span class='warning'>You grip \the [name] too hard and accidentally close it!</span>")
 		unwield()
 		return
 	if((CLUMSY in user.mutations) && prob(40))
-		to_chat(user, "<span class='warning'>You twirl around a bit before losing your balance and impaling yourself on [name]. Oof! Right through the armpit!</span>")
+		to_chat(user, "<span class='warning'>You twirl around a bit before losing your balance and impaling yourself on \the [name]. Oof! Right through the armpit!</span>")
 		return			//Note: I want this to knock them down or do stamina damage, but it IS just a toy x3
 	if(prob(50))
 		INVOKE_ASYNC(src, .proc/jedi_spin, user)
 	var/mob/U = user	//Recast as lower class to match class of mob/target
 	if(target == U)
-		to_chat(user, "<span class='warning'>You hit yourself with [name]! Be careful! This toy is dangerous!</span>")
+		to_chat(user, "<span class='warning'>You hit yourself with \the [name]! Be careful! This toy is dangerous!</span>")
 	else
-		to_chat(target, "<span class='warning'>You thought you were the chosen one. But [user] had the high ground and they got you good with [name].</span>")
+		to_chat(target, "<span class='warning'>You thought you were the chosen one. But [user] had the high ground and they got you good with \the [name].</span>")
 	return
 
 /obj/item/toy/katana

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -199,7 +199,7 @@
  */
 /obj/item/twohanded/dualsaber/toy
 	name = "double-bladed toy sword"
-	desc = "A cheap, plastic replica of TWO energy swords.  Double the fun!"
+	desc = "A cheap, plastic replica of TWO energy swords. Double the fun!"
 	force = 0
 	throwforce = 0
 	throw_speed = 3
@@ -207,7 +207,7 @@
 	force_unwielded = 0
 	force_wielded = 0
 	origin_tech = null
-	attack_verb = list("attacked", "struck", "hit")
+	attack_verb = list("attacked", "struck", "hit", "defeated youngling")
 	brightness_on = 0
 	sharp_when_wielded = FALSE // It's a toy
 	needs_permit = FALSE
@@ -218,6 +218,25 @@
 /obj/item/twohanded/dualsaber/toy/IsReflect()
 	if(wielded)
 		return 2
+
+/obj/item/twohanded/dualsaber/toy/attack(mob/target, mob/living/user)
+	if(!wielded)
+		return
+	if(HULK in user.mutations)
+		to_chat(user, "<span class='warning'>You grip the [name] too hard and accidentally close it!</span>")
+		unwield()
+		return
+	if((CLUMSY in user.mutations) && prob(40))
+		to_chat(user, "<span class='warning'>You twirl around a bit before losing your balance and impaling yourself on [name]. Oof! Right through the armpit!</span>")
+		return			//Note: I want this to knock them down or do stamina damage, but it IS just a toy x3
+	if(prob(50))
+		INVOKE_ASYNC(src, .proc/jedi_spin, user)
+	var/mob/U = user	//Recast as lower class to match class of mob/target
+	if(target == U)
+		to_chat(user, "<span class='warning'>You hit yourself with [name]! Be careful! This toy is dangerous!</span>")
+	else
+		to_chat(target, "<span class='warning'>You thought you were the chosen one. But [user] had the high ground and they got you good with [name].</span>")
+	return
 
 /obj/item/toy/katana
 	name = "replica katana"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Makes the Toy Double E-Sword actually safe.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This toy was not safe.
It was not meant for children or clowns.
Now it is.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can no longer hurt yourself with the Toy Double E-Sword
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
