### PR TITLE
Sleep No More

### DIFF
--- a/code/__DEFINES/stat.dm
+++ b/code/__DEFINES/stat.dm
@@ -1,7 +1,8 @@
 //mob/var/stat things
-#define CONSCIOUS	0
-#define UNCONSCIOUS	1
-#define DEAD		2
+#define CONSCIOUS		0
+#define UNCONSCIOUS		1
+#define DEAD			2
+#define ANESTHETIZED	3
 
 // TGUI flags
 #define STATUS_INTERACTIVE 2 // GREEN Visability

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -525,6 +525,8 @@ GLOBAL_LIST_INIT(do_after_once_tracker, list())
 				status = "<font color='orange'><b>Unconscious</b></font>"
 			if(DEAD)
 				status = "<font color='red'><b>Dead</b></font>"
+			if(ANESTHETIZED)
+				status = "<font color='blue'<b>Anesthetized</b></font>"
 		health_description = "Status = [status]"
 		health_description += "<BR>Oxy: [L.getOxyLoss()] - Tox: [L.getToxLoss()] - Fire: [L.getFireLoss()] - Brute: [L.getBruteLoss()] - Clone: [L.getCloneLoss()] - Brain: [L.getBrainLoss()]"
 	else

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -301,9 +301,7 @@
 	switch(stat)
 		if(CONSCIOUS)
 			holder.icon_state = "hudstat"
-		if(UNCONSCIOUS)
-			holder.icon_state = "hudoffline"
-		if(ANESTHEIZED)
+		if(UNCONSCIOUS,ANESTHETIZED)
 			holder.icon_state = "hudoffline"
 		else
 			holder.icon_state = "huddead2"

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -303,6 +303,8 @@
 			holder.icon_state = "hudstat"
 		if(UNCONSCIOUS)
 			holder.icon_state = "hudoffline"
+		if(ANESTHEIZED)
+			holder.icon_state = "hudoffline"
 		else
 			holder.icon_state = "huddead2"
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -370,7 +370,7 @@
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Dead)\n"
 					continue //Dead
 				if(L.stat == ANESTHETIZED)
-					msg += "<b>[L.name</b> ([L.ckey]), the [L.job] (Anesthetized)\n"
+					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Anesthetized)\n"
 
 			continue //Happy connected client
 		for(var/mob/dead/observer/D in GLOB.mob_list)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -369,6 +369,8 @@
 				if(L.stat == DEAD)
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Dead)\n"
 					continue //Dead
+				if(L.stat == ANESTHETIZED)
+					msg += "<b>[L.name</b> ([L.ckey]), the [L.job] (Anesthetized)\n"
 
 			continue //Happy connected client
 		for(var/mob/dead/observer/D in GLOB.mob_list)

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -191,6 +191,8 @@
 		patientStatus = "Awake"
 	else if(table.patient.stat == UNCONSCIOUS)
 		patientStatus = "Asleep"
+	else if(table.patient.stat == ANESTHETIZED)
+		patientStatus = "Anesthetized"
 
 	if(isNewPatient)
 		atom_say("New patient detected, loading stats")

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -723,6 +723,8 @@ REAGENT SCANNER
 			t1 = "Conscious"
 		if(UNCONSCIOUS)
 			t1 = "Unconscious"
+		if(ANESTHETIZED)
+			t1 = "Anesthetized"
 		else
 			t1 = "*dead*"
 	dat += "[target.health > 50 ? "<font color='blue'>" : "<font color='red'>"]\tHealth %: [target.health], ([t1])</font><br>"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -20,6 +20,8 @@
 			switch(C.mob.stat)
 				if(UNCONSCIOUS)
 					entry += " - <font color='darkgray'><b>Unconscious</b></font>"
+				if(ANESTHETIZED)
+					entry += " - <font color='darkgray'><b>Anesthetized</b></font>"
 				if(DEAD)
 					if(isobserver(C.mob))
 						var/mob/dead/observer/O = C.mob

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -49,7 +49,7 @@
 /mob/living/carbon/proc/experience_dream(dream_image, isNightmare)
 	dreaming--
 	nightmare--
-	if(stat != UNCONSCIOUS || InCritical())
+	if(stat != (UNCONSCIOUS || ANESTHETIZED)|| InCritical())
 		return
 	if(isNightmare)
 		dream_image = "<span class='cultitalic'>[dream_image]</span>"

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -49,7 +49,7 @@
 /mob/living/carbon/proc/experience_dream(dream_image, isNightmare)
 	dreaming--
 	nightmare--
-	if(stat != (UNCONSCIOUS || ANESTHETIZED)|| InCritical())
+	if(stat != (UNCONSCIOUS | ANESTHETIZED)|| InCritical())
 		return
 	if(isNightmare)
 		dream_image = "<span class='cultitalic'>[dream_image]</span>"

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -70,7 +70,7 @@
 			italics = TRUE
 			sound_vol *= 0.5
 
-	if(sleeping || stat == UNCONSCIOUS)
+	if(sleeping || stat == (UNCONSCIOUS || ANESTHETIZED))
 		hear_sleep(multilingual_to_message(message_pieces))
 		return 0
 
@@ -118,7 +118,7 @@
 	if(!client)
 		return
 
-	if(sleeping || stat == UNCONSCIOUS) //If unconscious or sleeping
+	if(sleeping || stat == (UNCONSCIOUS || ANESTHETIZED)) //If unconscious or sleeping
 		hear_sleep(multilingual_to_message(message_pieces))
 		return
 
@@ -182,7 +182,7 @@
 	to_chat(src, heard)
 
 /mob/proc/hear_holopad_talk(list/message_pieces, verb = "says", mob/speaker = null, obj/effect/overlay/holo_pad_hologram/H)
-	if(sleeping || stat == UNCONSCIOUS)
+	if(sleeping || stat == (UNCONSCIOUS || ANESTHETIZED))
 		hear_sleep(multilingual_to_message(message_pieces))
 		return
 

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -70,7 +70,7 @@
 			italics = TRUE
 			sound_vol *= 0.5
 
-	if(sleeping || stat == (UNCONSCIOUS || ANESTHETIZED))
+	if(sleeping || stat == (UNCONSCIOUS | ANESTHETIZED))
 		hear_sleep(multilingual_to_message(message_pieces))
 		return 0
 
@@ -118,7 +118,7 @@
 	if(!client)
 		return
 
-	if(sleeping || stat == (UNCONSCIOUS || ANESTHETIZED)) //If unconscious or sleeping
+	if(sleeping || stat == (UNCONSCIOUS | ANESTHETIZED)) //If unconscious or sleeping
 		hear_sleep(multilingual_to_message(message_pieces))
 		return
 
@@ -182,7 +182,7 @@
 	to_chat(src, heard)
 
 /mob/proc/hear_holopad_talk(list/message_pieces, verb = "says", mob/speaker = null, obj/effect/overlay/holo_pad_hologram/H)
-	if(sleeping || stat == (UNCONSCIOUS || ANESTHETIZED))
+	if(sleeping || stat == (UNCONSCIOUS | ANESTHETIZED))
 		hear_sleep(multilingual_to_message(message_pieces))
 		return
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -58,7 +58,7 @@
 	. = ..()
 	if(real)//So that giant red text about probisci doesn't show up for fake ones
 		switch(stat)
-			if(DEAD,UNCONSCIOUS)
+			if(DEAD,UNCONSCIOUS,ANESTHETIZED)
 				. += "<span class='boldannounce'>[src] is not moving.</span>"
 			if(CONSCIOUS)
 				. += "<span class='boldannounce'>[src] seems to be active!</span>"
@@ -197,7 +197,7 @@
 	icon_state = "[initial(icon_state)]"
 
 /obj/item/clothing/mask/facehugger/proc/GoIdle()
-	if(stat == DEAD || stat == UNCONSCIOUS)
+	if(stat != CONSCIOUS)
 		return
 
 	stat = UNCONSCIOUS

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -231,7 +231,7 @@
 				M.visible_message("<span class='notice'>[M] shakes [src], but [p_they()] [p_do()] not respond. Probably suffering from SSD.", \
 				"<span class='notice'>You shake [src], but [p_theyre()] unresponsive. Probably suffering from SSD.</span>")
 			if(lying) // /vg/: For hugs. This is how update_icon figgers it out, anyway.  - N3X15
-				add_attack_logs(M, src, "Shaked", ATKLOG_ALL)
+				add_attack_logs(M, src, "Shaken", ATKLOG_ALL)
 				if(ishuman(src))
 					var/mob/living/carbon/human/H = src
 					if(H.w_uniform)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -320,7 +320,7 @@
 	msg += "</span>"
 
 	if(!appears_dead)
-		if(stat == UNCONSCIOUS)
+		if(stat == (UNCONSCIOUS || ANESTHETIZED))
 			msg += "[p_they(TRUE)] [p_are()]n't responding to anything around [p_them()] and seems to be asleep.\n"
 		else if(getBrainLoss() >= 60)
 			msg += "[p_they(TRUE)] [p_have()] a stupid expression on [p_their()] face.\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -320,7 +320,7 @@
 	msg += "</span>"
 
 	if(!appears_dead)
-		if(stat == (UNCONSCIOUS || ANESTHETIZED))
+		if(stat == (UNCONSCIOUS | ANESTHETIZED))
 			msg += "[p_they(TRUE)] [p_are()]n't responding to anything around [p_them()] and seems to be asleep.\n"
 		else if(getBrainLoss() >= 60)
 			msg += "[p_they(TRUE)] [p_have()] a stupid expression on [p_their()] face.\n"

--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -18,14 +18,14 @@
 		amount = dna.species.spec_stun(src,amount)
 	return ..()
 
-/mob/living/carbon/human/SetParalysis(amount, updating = 1, force = 0)
+/mob/living/carbon/human/SetParalysis(amount, updating = 1, force = 0, ane = FALSE)
 	if(dna.species.stun_mod)
 		amount = amount * dna.species.stun_mod
 	else
 		amount = dna.species.spec_stun(src,amount)
 	return ..()
 
-/mob/living/carbon/human/SetSleeping(amount, updating = 1, no_alert = FALSE)
+/mob/living/carbon/human/SetSleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
 	if(dna.species.stun_mod)
 		amount = amount * dna.species.stun_mod
 	else

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -176,7 +176,7 @@
 		if(SA_partialpressure > SA_para_min)
 			Paralyse(3)
 			if(SA_partialpressure > SA_sleep_min)
-				AdjustSleeping(2, bound_lower = 0, bound_upper = 10)
+				AdjustSleeping(2, 0, 10, TRUE, FALSE, TRUE) //Amount=2, bound_lower=0,bound_upper=10,updating=TRUE,no_alert=FALSE,ane=TRUE
 		else if(SA_partialpressure > 0.01)
 			if(prob(20))
 				emote(pick("giggle","laugh"))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -174,9 +174,9 @@
 	//TRACE GASES
 	if(breath.sleeping_agent)
 		if(SA_partialpressure > SA_para_min)
-			Paralyse(3)
+			Paralyse(3, TRUE, 0, TRUE)						//amount=3,updating=TRUE,force=0,ane=TRUE
 			if(SA_partialpressure > SA_sleep_min)
-				AdjustSleeping(2, 0, 10, TRUE, FALSE, TRUE) //Amount=2, bound_lower=0,bound_upper=10,updating=TRUE,no_alert=FALSE,ane=TRUE
+				AdjustSleeping(2, 0, 10, TRUE, FALSE, TRUE) //amount=2,bound_lower=0,bound_upper=10,updating=TRUE,no_alert=FALSE,ane=TRUE
 		else if(SA_partialpressure > 0.01)
 			if(prob(20))
 				emote(pick("giggle","laugh"))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -404,7 +404,7 @@
 /mob/living/carbon/update_damage_hud()
 	if(!client)
 		return
-	if(stat == (UNCONSCIOUS || ANESTHETIZED) && health <= HEALTH_THRESHOLD_CRIT)
+	if(stat == (UNCONSCIOUS | ANESTHETIZED) && health <= HEALTH_THRESHOLD_CRIT)
 		if(check_death_method())
 			var/severity = 0
 			switch(health)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -320,10 +320,13 @@
 		AdjustDizzy(-restingpwr)
 
 	if(drowsyness)
-		AdjustDrowsy(-restingpwr)
+		var/ane = FALSE
+		if(anesthetized)
+			ane = TRUE
+		AdjustDrowsy(-restingpwr, ane)
 		EyeBlurry(2)
 		if(prob(5))
-			AdjustSleeping(1)
+			AdjustSleeping(1, 0, INFINITY, 1, FALSE, ane)
 			Paralyse(5)
 
 	if(confused)
@@ -401,7 +404,7 @@
 /mob/living/carbon/update_damage_hud()
 	if(!client)
 		return
-	if(stat == UNCONSCIOUS && health <= HEALTH_THRESHOLD_CRIT)
+	if(stat == (UNCONSCIOUS || ANESTHETIZED) && health <= HEALTH_THRESHOLD_CRIT)
 		if(check_death_method())
 			var/severity = 0
 			switch(health)

--- a/code/modules/mob/living/carbon/update_status.dm
+++ b/code/modules/mob/living/carbon/update_status.dm
@@ -11,7 +11,7 @@
 				KnockOut(TRUE, anesthetized)
 				create_debug_log("fell unconscious, trigger reason: [reason]")
 		else
-			if(stat == (UNCONSCIOUS || ANESTHETIZED))
+			if(stat == (UNCONSCIOUS | ANESTHETIZED))
 				WakeUp()
 				create_debug_log("woke up, trigger reason: [reason]")
 	update_damage_hud()

--- a/code/modules/mob/living/carbon/update_status.dm
+++ b/code/modules/mob/living/carbon/update_status.dm
@@ -6,7 +6,7 @@
 			death()
 			create_debug_log("died of damage, trigger reason: [reason]")
 			return
-		if(paralysis || sleeping || (check_death_method() && getOxyLoss() > 50) || (status_flags & FAKEDEATH) || health <= HEALTH_THRESHOLD_CRIT && check_death_method())
+		if(sleeping || paralysis || (check_death_method() && getOxyLoss() > 50) || (status_flags & FAKEDEATH) || health <= HEALTH_THRESHOLD_CRIT && check_death_method())
 			if(stat == CONSCIOUS)
 				KnockOut(TRUE, anesthetized)
 				create_debug_log("fell unconscious, trigger reason: [reason]")

--- a/code/modules/mob/living/carbon/update_status.dm
+++ b/code/modules/mob/living/carbon/update_status.dm
@@ -8,10 +8,10 @@
 			return
 		if(paralysis || sleeping || (check_death_method() && getOxyLoss() > 50) || (status_flags & FAKEDEATH) || health <= HEALTH_THRESHOLD_CRIT && check_death_method())
 			if(stat == CONSCIOUS)
-				KnockOut()
+				KnockOut(TRUE, anesthetized)
 				create_debug_log("fell unconscious, trigger reason: [reason]")
 		else
-			if(stat == UNCONSCIOUS)
+			if(stat == (UNCONSCIOUS || ANESTHETIZED))
 				WakeUp()
 				create_debug_log("woke up, trigger reason: [reason]")
 	update_damage_hud()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -277,8 +277,7 @@
 
 
 /mob/living/proc/InCritical()
-	return (health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD && stat == UNCONSCIOUS)
-
+	return (health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD && stat == UNCONSCIOUS) //Does this need ANESTHETIZED? Please Review
 
 /mob/living/ex_act(severity)
 	..()
@@ -497,7 +496,7 @@
 	surgeries.Cut() //End all surgeries.
 	if(stat == DEAD)
 		update_revive()
-	else if(stat == UNCONSCIOUS)
+	else if(stat == (UNCONSCIOUS || ANESTHETIZED))
 		WakeUp()
 
 	update_fire()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -496,7 +496,7 @@
 	surgeries.Cut() //End all surgeries.
 	if(stat == DEAD)
 		update_revive()
-	else if(stat == (UNCONSCIOUS || ANESTHETIZED))
+	else if(stat == (UNCONSCIOUS | ANESTHETIZED))
 		WakeUp()
 
 	update_fire()

--- a/code/modules/mob/living/silicon/pai/software/pai_apps.dm
+++ b/code/modules/mob/living/silicon/pai/software/pai_apps.dm
@@ -378,7 +378,7 @@
 
 	if(isliving(held))
 		data["holder"] = held.name
-		data["dead"] = (held.stat > UNCONSCIOUS)
+		data["dead"] = (held.stat == DEAD)
 		data["health"] = held.health
 		data["brute"] = held.getBruteLoss()
 		data["oxy"] = held.getOxyLoss()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -57,7 +57,7 @@
 	if(stat != CONSCIOUS)
 		uneq_all()
 
-	if(!is_component_functioning("radio") || stat == (UNCONSCIOUS || ANESTHETIZED))
+	if(!is_component_functioning("radio") || stat == (UNCONSCIOUS | ANESTHETIZED))
 		radio.on = 0
 	else
 		radio.on = 1

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -57,7 +57,7 @@
 	if(stat != CONSCIOUS)
 		uneq_all()
 
-	if(!is_component_functioning("radio") || stat == UNCONSCIOUS)
+	if(!is_component_functioning("radio") || stat == (UNCONSCIOUS || ANESTHETIZED))
 		radio.on = 0
 	else
 		radio.on = 1

--- a/code/modules/mob/living/silicon/robot/update_status.dm
+++ b/code/modules/mob/living/silicon/robot/update_status.dm
@@ -20,7 +20,7 @@
 				update_headlamp()
 				create_debug_log("fell unconscious, trigger reason: [reason]")
 		else
-			if(stat == UNCONSCIOUS)
+			if(stat == (UNCONSCIOUS || ANESTHETIZED))
 				WakeUp()
 				update_headlamp()
 				create_debug_log("woke up, trigger reason: [reason]")

--- a/code/modules/mob/living/silicon/robot/update_status.dm
+++ b/code/modules/mob/living/silicon/robot/update_status.dm
@@ -20,7 +20,7 @@
 				update_headlamp()
 				create_debug_log("fell unconscious, trigger reason: [reason]")
 		else
-			if(stat == (UNCONSCIOUS || ANESTHETIZED))
+			if(stat == (UNCONSCIOUS | ANESTHETIZED)) //Look, I don't know how a robot became ANESTHETIZED - what you do in your own time is your own business!
 				WakeUp()
 				update_headlamp()
 				create_debug_log("woke up, trigger reason: [reason]")

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -1,28 +1,33 @@
 // There, now `stat` is a proper state-machine
 
-/mob/living/proc/KnockOut(updating = 1)
+/mob/living/proc/KnockOut(updating = TRUE, anesthetized = FALSE)
 	if(stat == DEAD)
 		log_runtime(EXCEPTION("KnockOut called on a dead mob."), src)
-		return 0
-	else if(stat == UNCONSCIOUS)
-		return 0
+		return FALSE
+	else if(stat == (UNCONSCIOUS || ANESTHETIZED))
+		return FALSE
 	create_attack_log("<font color='red'>Fallen unconscious at [atom_loc_line(get_turf(src))]</font>")
 	add_attack_logs(src, null, "Fallen unconscious", ATKLOG_ALL)
 	log_game("[key_name(src)] fell unconscious at [atom_loc_line(get_turf(src))]")
-	stat = UNCONSCIOUS
+
+	if(anesthetized)
+		stat = ANESTHETIZED
+	else
+		stat = UNCONSCIOUS
+
 	if(updating)
 		update_sight()
 		update_blind_effects()
 		update_canmove()
 		set_typing_indicator(FALSE)
-	return 1
+	return TRUE
 
 /mob/living/proc/WakeUp(updating = 1)
 	if(stat == DEAD)
 		log_runtime(EXCEPTION("WakeUp called on a dead mob."), src)
-		return 0
+		return FALSE
 	else if(stat == CONSCIOUS)
-		return 0
+		return FALSE
 	create_attack_log("<font color='red'>Woken up at [atom_loc_line(get_turf(src))]</font>")
 	add_attack_logs(src, null, "Woken up", ATKLOG_ALL)
 	log_game("[key_name(src)] woke up at [atom_loc_line(get_turf(src))]")
@@ -31,7 +36,7 @@
 		update_sight()
 		update_blind_effects()
 		update_canmove()
-	return 1
+	return TRUE
 
 /mob/living/proc/can_be_revived()
 	. = TRUE

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -6,20 +6,24 @@
 		return FALSE
 	else if(stat == (UNCONSCIOUS || ANESTHETIZED))
 		return FALSE
-	create_attack_log("<font color='red'>Fallen unconscious at [atom_loc_line(get_turf(src))]</font>")
-	add_attack_logs(src, null, "Fallen unconscious", ATKLOG_ALL)
-	log_game("[key_name(src)] fell unconscious at [atom_loc_line(get_turf(src))]")
 
 	if(anesthetized)
 		stat = ANESTHETIZED
+		create_attack_log("<font color='red'>Anesthetized at [atom_loc_line(get_turf(src))]</font>")
+		add_attack_logs(src, null, "Anesthetized", ATKLOG_ALL)
+		log_game("[key_name(src)] was anesthetized at [atom_loc_line(get_turf(src))]")
 	else
 		stat = UNCONSCIOUS
+		create_attack_log("<font color='red'>Fallen unconscious at [atom_loc_line(get_turf(src))]</font>")
+		add_attack_logs(src, null, "Fallen unconscious", ATKLOG_ALL)
+		log_game("[key_name(src)] fell unconscious at [atom_loc_line(get_turf(src))]")
 
 	if(updating)
 		update_sight()
 		update_blind_effects()
 		update_canmove()
 		set_typing_indicator(FALSE)
+
 	return TRUE
 
 /mob/living/proc/WakeUp(updating = 1)

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -4,9 +4,8 @@
 	if(stat == DEAD)
 		log_runtime(EXCEPTION("KnockOut called on a dead mob."), src)
 		return FALSE
-	else if(stat == (UNCONSCIOUS || ANESTHETIZED))
+	else if(stat == (UNCONSCIOUS | ANESTHETIZED))
 		return FALSE
-
 	if(anesthetized)
 		stat = ANESTHETIZED
 		create_attack_log("<font color='red'>Anesthetized at [atom_loc_line(get_turf(src))]</font>")

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -298,6 +298,7 @@
 	return SetParalysis(max(paralysis, amount), updating, force, ane)
 
 /mob/living/SetParalysis(amount, updating = 1, force = 0, ane = FALSE)
+	anesthetized = ane
 	. = STATUS_UPDATE_STAT
 	if((!!amount) == (!!paralysis)) // We're not changing from + to 0 or vice versa
 		updating = FALSE
@@ -305,7 +306,6 @@
 	if(status_flags & CANPARALYSE || force)
 		paralysis = max(amount, 0)
 		if(updating)
-			anesthetized = ane
 			update_canmove()
 			update_stat("paralysis")
 
@@ -333,13 +333,13 @@
 /mob/living/SetSleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
 	if(frozen) // If the mob has been admin frozen, sleeping should not be changeable
 		return
+	anesthetized = ane
 	. = STATUS_UPDATE_STAT
 	if((!!amount) == (!!sleeping)) // We're not changing from + to 0 or vice versa
 		updating = FALSE
 		. = STATUS_UPDATE_NONE
 	sleeping = max(amount, 0)
 	if(updating)
-		anesthetized = ane
 		update_sleeping_effects(no_alert)
 		update_canmove()
 		update_stat("sleeping")

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -124,6 +124,7 @@
 	var/stunned = 0
 	var/stuttering = 0
 	var/weakened = 0
+	var/anesthetized = FALSE
 
 // RESTING
 
@@ -170,15 +171,16 @@
 
 // DROWSY
 
-/mob/living/Drowsy(amount)
-	SetDrowsy(max(drowsyness, amount))
+/mob/living/Drowsy(amount, ane = FALSE)
+	SetDrowsy(max(drowsyness, amount), ane)
 
-/mob/living/SetDrowsy(amount)
+/mob/living/SetDrowsy(amount, ane = FALSE)
 	drowsyness = max(amount, 0)
+	anesthetized = ane
 
-/mob/living/AdjustDrowsy(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/AdjustDrowsy(amount, bound_lower = 0, bound_upper = INFINITY, ane = FALSE)
 	var/new_value = directional_bounded_sum(drowsyness, amount, bound_lower, bound_upper)
-	SetDrowsy(new_value)
+	SetDrowsy(new_value, ane)
 
 // DRUNK
 
@@ -324,10 +326,10 @@
 
 // SLEEPING
 
-/mob/living/Sleeping(amount, updating = 1, no_alert = FALSE)
+/mob/living/Sleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
 	return SetSleeping(max(sleeping, amount), updating, no_alert)
 
-/mob/living/SetSleeping(amount, updating = 1, no_alert = FALSE)
+/mob/living/SetSleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
 	if(frozen) // If the mob has been admin frozen, sleeping should not be changeable
 		return
 	. = STATUS_UPDATE_STAT
@@ -336,13 +338,15 @@
 		. = STATUS_UPDATE_NONE
 	sleeping = max(amount, 0)
 	if(updating)
+		anesthetized = ane
 		update_sleeping_effects(no_alert)
-		update_stat("sleeping")
 		update_canmove()
+		update_stat("sleeping")
 
-/mob/living/AdjustSleeping(amount, bound_lower = 0, bound_upper = INFINITY, updating = 1, no_alert = FALSE)
+
+/mob/living/AdjustSleeping(amount, bound_lower = 0, bound_upper = INFINITY, updating = 1, no_alert = FALSE, ane = FALSE)
 	var/new_value = directional_bounded_sum(sleeping, amount, bound_lower, bound_upper)
-	return SetSleeping(new_value, updating, no_alert)
+	return SetSleeping(new_value, updating, no_alert, ane)
 
 // SLOWED
 

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -343,7 +343,6 @@
 		update_canmove()
 		update_stat("sleeping")
 
-
 /mob/living/AdjustSleeping(amount, bound_lower = 0, bound_upper = INFINITY, updating = 1, no_alert = FALSE, ane = FALSE)
 	var/new_value = directional_bounded_sum(sleeping, amount, bound_lower, bound_upper)
 	return SetSleeping(new_value, updating, no_alert, ane)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -294,10 +294,10 @@
 
 // PARALYSE
 
-/mob/living/Paralyse(amount, updating = 1, force = 0)
-	return SetParalysis(max(paralysis, amount), updating, force)
+/mob/living/Paralyse(amount, updating = 1, force = 0, ane = FALSE)
+	return SetParalysis(max(paralysis, amount), updating, force, ane)
 
-/mob/living/SetParalysis(amount, updating = 1, force = 0)
+/mob/living/SetParalysis(amount, updating = 1, force = 0, ane = FALSE)
 	. = STATUS_UPDATE_STAT
 	if((!!amount) == (!!paralysis)) // We're not changing from + to 0 or vice versa
 		updating = FALSE
@@ -305,12 +305,13 @@
 	if(status_flags & CANPARALYSE || force)
 		paralysis = max(amount, 0)
 		if(updating)
+			anesthetized = ane
 			update_canmove()
 			update_stat("paralysis")
 
-/mob/living/AdjustParalysis(amount, bound_lower = 0, bound_upper = INFINITY, updating = 1, force = 0)
+/mob/living/AdjustParalysis(amount, bound_lower = 0, bound_upper = INFINITY, updating = 1, force = 0, ane = FALSE)
 	var/new_value = directional_bounded_sum(paralysis, amount, bound_lower, bound_upper)
-	return SetParalysis(new_value, updating, force)
+	return SetParalysis(new_value, updating, force, ane)
 
 // SILENT
 
@@ -327,7 +328,7 @@
 // SLEEPING
 
 /mob/living/Sleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
-	return SetSleeping(max(sleeping, amount), updating, no_alert)
+	return SetSleeping(max(sleeping, amount), updating, no_alert, ane)
 
 /mob/living/SetSleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
 	if(frozen) // If the mob has been admin frozen, sleeping should not be changeable

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -123,6 +123,8 @@
 			SetParalysis(paralysis)
 		if("sleeping")
 			SetSleeping(sleeping)
+		if("anesthetized")
+			SetSleeping(anesthetized)
 		if("eye_blind")
 			SetEyeBlind(eye_blind)
 		if("eye_blurry")

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -123,8 +123,6 @@
 			SetParalysis(paralysis)
 		if("sleeping")
 			SetSleeping(sleeping)
-		if("anesthetized")
-			SetSleeping(anesthetized)
 		if("eye_blind")
 			SetEyeBlind(eye_blind)
 		if("eye_blurry")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -89,7 +89,7 @@
 				if(type & 1 && !has_vision(information_only=TRUE))
 					return
 	// Added voice muffling for Issue 41.
-	if(stat == (UNCONSCIOUS || ANESTHETIZED) || (sleeping > 0 && stat != DEAD))
+	if(stat == (UNCONSCIOUS | ANESTHETIZED) || (sleeping > 0 && stat != DEAD))
 		to_chat(src, "<I>... You can almost hear someone talking ...</I>")
 	else
 		to_chat(src, msg)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -89,7 +89,7 @@
 				if(type & 1 && !has_vision(information_only=TRUE))
 					return
 	// Added voice muffling for Issue 41.
-	if(stat == UNCONSCIOUS || (sleeping > 0 && stat != DEAD))
+	if(stat == (UNCONSCIOUS || ANESTHETIZED) || (sleeping > 0 && stat != DEAD))
 		to_chat(src, "<I>... You can almost hear someone talking ...</I>")
 	else
 		to_chat(src, msg)

--- a/code/modules/pda/app.dm
+++ b/code/modules/pda/app.dm
@@ -33,7 +33,7 @@
 		else
 			L = get(pda, /mob/living/silicon)
 
-		if(L && L.stat != (UNCONSCIOUS || ANESTHETIZED)) // Awake or dead people can see their messages
+		if(L && L.stat != (UNCONSCIOUS | ANESTHETIZED)) // Awake or dead people can see their messages
 			to_chat(L, "[bicon(pda)] [message]")
 			SStgui.update_user_uis(L, pda) // Update the receiving user's PDA UI so that they can see the new message
 

--- a/code/modules/pda/app.dm
+++ b/code/modules/pda/app.dm
@@ -33,7 +33,7 @@
 		else
 			L = get(pda, /mob/living/silicon)
 
-		if(L && L.stat != UNCONSCIOUS) // Awake or dead people can see their messages
+		if(L && L.stat != (UNCONSCIOUS || ANESTHETIZED)) // Awake or dead people can see their messages
 			to_chat(L, "[bicon(pda)] [message]")
 			SStgui.update_user_uis(L, pda) // Update the receiving user's PDA UI so that they can see the new message
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -1038,10 +1038,10 @@
 			if(prob(7))
 				M.emote("yawn")
 		if(31 to 40)
-			M.Drowsy(20)
+			M.Drowsy(20, TRUE)
 		if(41 to INFINITY)
 			update_flags |= M.Paralyse(15, FALSE)
-			M.Drowsy(20)
+			M.Drowsy(20, TRUE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/syndicate_nanites //Used exclusively by Syndicate medical cyborgs

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -111,7 +111,7 @@
 
 
 /proc/get_pain_modifier(mob/living/carbon/human/M) //returns modfier to make surgery harder if patient is conscious and feels pain
-	if(M.stat) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too. Just sleeping won't work, though.
+	if(M.stat) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS, 2=DEAD, 3=ANESTHETIZED. Operating on dead people is easy, too. Just sleeping won't work, though.
 		return 1
 	if(NO_PAIN in M.dna.species.species_traits)//if you don't feel pain, you can hold still
 		return 1

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -172,7 +172,7 @@
 	..()
 	if(crit_fail)
 		return
-	if(owner.stat == UNCONSCIOUS && cooldown == FALSE)
+	if(owner.stat == (UNCONSCIOUS || ANESTHETIZED) && cooldown == FALSE)
 		owner.AdjustSleeping(-100, FALSE)
 		owner.AdjustParalysis(-100, FALSE)
 		to_chat(owner, "<span class='notice'>You feel a rush of energy course through your body!</span>")

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -172,7 +172,7 @@
 	..()
 	if(crit_fail)
 		return
-	if(owner.stat == (UNCONSCIOUS || ANESTHETIZED) && cooldown == FALSE)
+	if(owner.stat == (UNCONSCIOUS | ANESTHETIZED) && cooldown == FALSE)
 		owner.AdjustSleeping(-100, FALSE)
 		owner.AdjustParalysis(-100, FALSE)
 		to_chat(owner, "<span class='notice'>You feel a rush of energy course through your body!</span>")

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -231,12 +231,12 @@
 
 	//-- TRACES --//
 
-	if(breath.sleeping_agent)	// If there's some other shit in the air lets deal with it here.
+	if(breath.sleeping_agent)				// If there's some other shit in the air lets deal with it here.
 		if(SA_pp > SA_para_min)
-			H.Paralyse(3) // 3 gives them one second to wake up and run away a bit!
-			if(SA_pp > SA_sleep_min) // Enough to make us sleep as well
-				H.AdjustSleeping(8, bound_lower = 0, bound_upper = 10)
-		else if(SA_pp > 0.01)	// There is sleeping gas in their lungs, but only a little, so give them a bit of a warning
+			H.Paralyse(3, TRUE, 0, TRUE)	// 3 gives them one second to wake up and run away a bit!
+			if(SA_pp > SA_sleep_min)		// Enough to make us sleep as well
+				H.AdjustSleeping(8, 0, 10, TRUE, FALSE, TRUE)	//amount=8,bound_lower=0,bound_upper=10,updating=TRUE,no_alert=FALSE,ane=TRUE
+		else if(SA_pp > 0.01)				// There is sleeping gas in their lungs, but only a little, so give them a bit of a warning
 			if(prob(20))
 				H.emote(pick("giggle", "laugh"))
 

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -5,9 +5,10 @@
 // partname is the name of a body part
 // amount is a num from 1 to 100
 /mob/living/carbon/human/proc/pain(partname, amount)
-	// not when Anesthetized or Dead
-	if(stat == DEAD || stat == ANESTHETIZED)
-		return
+	if(stat == (DEAD || ANESTHETIZED))
+		return				//No messages when Anesthetized or Dead
+	if(stat == UNCONSCIOUS)	//You can't sleep through the pain.
+		WakeUp()			//This is going to come back to bite us hard with antags.
 	if(reagents.has_reagent("sal_acid"))
 		return
 	if(reagents.has_reagent("morphine"))
@@ -32,9 +33,10 @@
 
 // message is the custom message to be displayed
 /mob/living/carbon/human/proc/custom_pain(message)
-	// not when Anesthetized or Dead
-	if(stat == DEAD || stat == ANESTHETIZED)
-		return
+	if(stat == (DEAD || ANESTHETIZED))
+		return				//No messages when Anesthetized or Dead
+	if(stat == UNCONSCIOUS)	//You can't sleep through the pain.
+		WakeUp()			//This is going to come back to bite us hard with antags.
 	if(NO_PAIN in dna.species.species_traits)
 		return
 	if(reagents.has_reagent("morphine"))

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -5,7 +5,8 @@
 // partname is the name of a body part
 // amount is a num from 1 to 100
 /mob/living/carbon/human/proc/pain(partname, amount)
-	if(stat >= UNCONSCIOUS)
+	// not when Anesthetized or Dead
+	if(stat == DEAD || stat == ANESTHETIZED)
 		return
 	if(reagents.has_reagent("sal_acid"))
 		return
@@ -31,9 +32,9 @@
 
 // message is the custom message to be displayed
 /mob/living/carbon/human/proc/custom_pain(message)
-	if(stat >= UNCONSCIOUS)
+	// not when Anesthetized or Dead
+	if(stat == DEAD || stat == ANESTHETIZED)
 		return
-
 	if(NO_PAIN in dna.species.species_traits)
 		return
 	if(reagents.has_reagent("morphine"))
@@ -50,9 +51,8 @@
 	next_pain_time = world.time + 100
 
 /mob/living/carbon/human/proc/handle_pain()
-	// not when sleeping
-
-	if(stat >= UNCONSCIOUS)
+	// not when Anesthetized or Dead
+	if(stat == DEAD || stat == ANESTHETIZED)
 		return
 	if(NO_PAIN in dna.species.species_traits)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

- Address Issue: https://github.com/ScorpioStation/ScorpioStation/issues/111
- This PR adds a new vitals stat called ANESTHETIZED which functions the same way as using the Sleep verb currently does for surgery.
- This PR makes it so you can no longer use the Sleep verb to get through surgery.
- This PR makes it so pain _**will always**_ wake up mobs who are UNCONSCIOUS.
- Pain will _**not**_ wake mobs who are ANESTHETIZED
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Mobs can no longer sleep through surgery.
- Surgery now requires either painkillers, ether, Anesthesia gas mixture, or N2O.
- Sorry, antags, putting people to sleep will now wake them up. Hey, I should check the Sleepy Pen reagents to make them do ANESTHETIZED instead.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
del: Sleeping through surgery, Sleeping through pain
wip: New stat: ANESTHETIZED
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
