### PR TITLE
Partial Revert: Kida Cannot Wear Glasses, Removes Hunger and Toxin Mo…

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -212,6 +212,7 @@
 	strip_delay = 20			//	   but seperated to allow items to protect but not impair vision, like space helmets
 	put_on_delay = 25
 	resistance_flags = NONE
+	species_restricted = list("exclude","Kidan")
 
 /*
 SEE_SELF  // can see self, no matter what

--- a/code/modules/mob/living/carbon/human/species/kidan.dm
+++ b/code/modules/mob/living/carbon/human/species/kidan.dm
@@ -7,8 +7,6 @@
 	unarmed_type = /datum/unarmed_attack/claws
 
 	brute_mod = 0.8
-	hunger_drain = 0.15
-	tox_mod = 1.7
 
 	species_traits = list(IS_WHITELISTED)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Partially reverts: https://github.com/ScorpioStation/ScorpioStation/pull/296/commits/256ecd0c16ad26b34f217501dd8299159874a50e

- Kida cannot wear glasses again
- No more hunger modifier
- No more Toxin modifier

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why

- Requested by players who main Kida
- Difference is beautiful

I want to say that I'm not knocking the original Paradise PR! I thought it was done very well and I think it works really well for the Paradise server. Scorpio runs a little differently with our ***much*** smaller playerbase.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Sorry Kida, you can't wear glasses again, but at least you're not hungry or toxin prone!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
