### PR TITLE
Adds validation for character fields headed to DB

### DIFF
--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -369,6 +369,12 @@
 	if(!isemptylist(loadout_gear))
 		gearlist = list2params(loadout_gear)
 
+	// correct fields that cannot be null before saving any characters
+	if(isnull(alt_head))
+		alt_head = initial(alt_head)
+	if(isnull(autohiss_mode))
+		autohiss_mode = initial(autohiss_mode)
+
 	var/datum/db_query/firstquery = SSdbcore.NewQuery("SELECT slot FROM [format_table_name("characters")] WHERE ckey=:ckey ORDER BY slot", list(
 		"ckey" = C.ckey
 	))


### PR DESCRIPTION
## What Does This PR Do
This adds some validation logic to patch up character fields that ended up `null`.

This fixes some errors that popped up in `sql.log`:
```text
MySqlError { ERROR 1048 (23000): Column 'autohiss' cannot be null } | Query used: UPDATE characters
MySqlError { ERROR 1048 (23000): Column 'alt_head_name' cannot be null } | Query used: UPDATE characters
```
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
* Players can save changes to their characters to the DB.
* Admins don't get scary SQL error messages.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Added validation code to head off DB errors when saving characters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
