### PR TITLE
Adds early vote to supercharge SMESs

### DIFF
--- a/_maps/map_files/emerald/emerald.dmm
+++ b/_maps/map_files/emerald/emerald.dmm
@@ -72,7 +72,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/storage/secure)
 "aap" = (
-/obj/machinery/particle_accelerator/control_box,
+/obj/machinery/particle_accelerator/control_box{
+	tag = "particle_accelerator_control_box"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/storage/secure)
 "aaq" = (

--- a/code/__DEFINES/vote_types.dm
+++ b/code/__DEFINES/vote_types.dm
@@ -1,0 +1,1 @@
+#define VOTE_TYPE_SUPERCHARGE "supercharge"

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -315,6 +315,9 @@ SUBSYSTEM_DEF(ticker)
 	else
 		log_debug("Playercount: [playercount] versus trigger: [highpop_trigger] - keeping standard job config")
 
+	// later, let's ask the players if they want power (if they don't have it yet)
+	addtimer(CALLBACK(SSvote, /datum/controller/subsystem/vote/.proc/initiate_vote, VOTE_TYPE_SUPERCHARGE), 15 MINUTES)
+
 	#ifdef UNIT_TESTS
 	RunUnitTests()
 	#endif

--- a/paradise.dme
+++ b/paradise.dme
@@ -83,6 +83,7 @@
 #include "code\__DEFINES\tgui.dm"
 #include "code\__DEFINES\tools.dm"
 #include "code\__DEFINES\typeids.dm"
+#include "code\__DEFINES\vote_types.dm"
 #include "code\__DEFINES\vv.dm"
 #include "code\__DEFINES\wires.dm"
 #include "code\__DEFINES\zlevel.dm"


### PR DESCRIPTION
## What Does This PR Do
Fifteen minutes after the round starts, we check the Particle Accelerator Control Panel to see if the Particle Accelerator has been turned on. If it has not, then a vote is launched:

Request Emergency Bluespace Power Transmission?
* Request Emergency Power Transmission
* Our Power Situation Is Under Control

If the players vote for an emergency power transmission, the SMESs are supercharged. (Closes #306)
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Per #306 , the players can supercharge the SMESs if they need to do it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added early vote to supercharge SMESs 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
