### PR TITLE
Autoban for Gamer Words

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -58,26 +58,32 @@ GLOBAL_PROTECT(log_end)
 		rustg_log_write(GLOB.world_game_log, "ACCESS OUT: [message][GLOB.log_end]")
 
 /proc/log_say(text, mob/speaker)
+	check_for_troll("Say", text, speaker)
 	if(config.log_say)
 		rustg_log_write(GLOB.world_game_log, "SAY: [speaker.simple_info_line()]: [html_decode(text)][GLOB.log_end]")
 
 /proc/log_whisper(text, mob/speaker)
+	check_for_troll("Whisper", text, speaker)
 	if(config.log_whisper)
 		rustg_log_write(GLOB.world_game_log, "WHISPER: [speaker.simple_info_line()]: [html_decode(text)][GLOB.log_end]")
 
 /proc/log_ooc(text, client/user)
+	check_for_troll("OOC", text, user)
 	if(config.log_ooc)
 		rustg_log_write(GLOB.world_game_log, "OOC: [user.simple_info_line()]: [html_decode(text)][GLOB.log_end]")
 
 /proc/log_aooc(text, client/user)
+	check_for_troll("AOOC", text, user)
 	if(config.log_ooc)
 		rustg_log_write(GLOB.world_game_log, "AOOC: [user.simple_info_line()]: [html_decode(text)][GLOB.log_end]")
 
 /proc/log_looc(text, client/user)
+	check_for_troll("LOOC", text, user)
 	if(config.log_ooc)
 		rustg_log_write(GLOB.world_game_log, "LOOC: [user.simple_info_line()]: [html_decode(text)][GLOB.log_end]")
 
 /proc/log_emote(text, mob/speaker)
+	check_for_troll("Emote", text, speaker)
 	if(config.log_emote)
 		rustg_log_write(GLOB.world_game_log, "EMOTE: [speaker.simple_info_line()]: [html_decode(text)][GLOB.log_end]")
 
@@ -97,10 +103,12 @@ GLOBAL_PROTECT(log_end)
 		rustg_log_write(GLOB.world_game_log, "MENTORSAY: [speaker.simple_info_line()]: [html_decode(text)][GLOB.log_end]")
 
 /proc/log_ghostsay(text, mob/speaker)
+	check_for_troll("Deadchat", text, speaker)
 	if(config.log_say)
 		rustg_log_write(GLOB.world_game_log, "DEADCHAT: [speaker.simple_info_line()]: [html_decode(text)][GLOB.log_end]")
 
 /proc/log_ghostemote(text, mob/speaker)
+	check_for_troll("Deadchat Emote", text, speaker)
 	if(config.log_emote)
 		rustg_log_write(GLOB.world_game_log, "DEADEMOTE: [speaker.simple_info_line()]: [html_decode(text)][GLOB.log_end]")
 
@@ -109,10 +117,12 @@ GLOBAL_PROTECT(log_end)
 		rustg_log_write(GLOB.world_game_log, "ADMINWARN: [html_decode(text)][GLOB.log_end]")
 
 /proc/log_pda(text, mob/speaker)
+	check_for_troll("PDA", text, speaker)
 	if(config.log_pda)
 		rustg_log_write(GLOB.world_game_log, "PDA: [speaker.simple_info_line()]: [html_decode(text)][GLOB.log_end]")
 
 /proc/log_chat(text, mob/speaker)
+	check_for_troll("Chat", text, speaker)
 	if(config.log_pda)
 		rustg_log_write(GLOB.world_game_log, "CHAT: [speaker.simple_info_line()] [html_decode(text)][GLOB.log_end]")
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -764,6 +764,9 @@
 				if("start_now_confirmation")
 					config.start_now_confirmation = 1
 
+				if("gamer_words")
+					add_gamer_words(value)
+
 				if("tick_limit_mc_init")
 					config.tick_limit_mc_init = text2num(value)
 				if("base_mc_tick_rate")

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -48,6 +48,9 @@ GLOBAL_DATUM_INIT(event_announcement, /datum/announcement/priority/command/event
 	if(!message)
 		return
 
+	if(check_for_troll(announcement_type, message, usr))
+		return
+
 	var/message_title = new_title ? new_title : title
 	var/message_sound = new_sound ? sound(new_sound) : sound
 

--- a/code/scorpio/troll.dm
+++ b/code/scorpio/troll.dm
@@ -1,0 +1,120 @@
+// troll.dm
+// Copyright 2021 Patrick Meade.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+GLOBAL_LIST_EMPTY(gamer_words)
+
+/proc/add_gamer_words(config_value)
+	GLOB.gamer_words += splittext(config_value, ",")
+
+/proc/ban_and_kick_troll(context, message, word, mob_name, client/ban_me)
+	ban_troll(context, message, word, mob_name, ban_me)
+	kick_troll(ban_me)
+
+/proc/ban_troll(context, message, word, mob_name, client/ban_me)
+	// we can't ban if we don't have a database
+	if(!SSdbcore.IsConnected())
+		log_and_message_admins("Database connection failure when attempting to ban troll [ban_me].")
+		return FALSE
+
+	// build up all the things we need to record the ban
+	var/serverip = "[world.internet_address]:[world.port]"
+	var/bantype_str = "PERMABAN"
+	var/reason = "[ban_me] / ([mob_name]) used gamer word '[word]' in [context] message [message]"
+	var/job = ""
+	var/duration = -1 // PERMABAN
+	var/rounds = 0
+	var/ckey = "[ban_me.ckey]"
+	var/computerid = "[ban_me.computer_id]"
+	var/ip = "[ban_me.address]"
+	var/a_ckey = "ScorpioStationAI"
+	var/a_computerid = 0x7f000001
+	var/a_ip = "127.0.0.1"
+	var/who = english_list(GLOB.clients)
+	var/adminwho = english_list(GLOB.admins)
+
+	// add the ban to the database
+	var/datum/db_query/query_insert = SSdbcore.NewQuery({"
+		INSERT INTO [format_table_name("ban")] (`id`,`bantime`,`serverip`,`bantype`,`reason`,`job`,`duration`,`rounds`,`expiration_time`,`ckey`,`computerid`,`ip`,`a_ckey`,`a_computerid`,`a_ip`,`who`,`adminwho`,`edits`,`unbanned`,`unbanned_datetime`,`unbanned_ckey`,`unbanned_computerid`,`unbanned_ip`)
+		VALUES (null, Now(), :serverip, :bantype_str, :reason, :job, :duration, :rounds, Now() + INTERVAL :duration MINUTE, :ckey, :computerid, :ip, :a_ckey, :a_computerid, :a_ip, :who, :adminwho, '', null, null, null, null, null)
+	"}, list(
+		// Get ready for parameters
+		"serverip" = serverip,
+		"bantype_str" = bantype_str,
+		"reason" = reason,
+		"job" = job,
+		"duration" = (duration ? "[duration]" : "0"), // strings are important here
+		"rounds" = (rounds ? "[rounds]" : "0"), // and here
+		"ckey" = ckey,
+		"computerid" = computerid,
+		"ip" = ip,
+		"a_ckey" = a_ckey,
+		"a_computerid" = a_computerid,
+		"a_ip" = a_ip,
+		"who" = who,
+		"adminwho" = adminwho
+	))
+	if(!query_insert.warn_execute())
+		qdel(query_insert)
+		return FALSE
+	qdel(query_insert)
+	log_and_message_admins("ScorpioStationAI has added a [bantype_str] for [ckey] with the reason: \"[reason]\" to the ban database.")
+
+	// tell Discord why we banned the mob
+	var/datum/discord/webhook/cryo = new(config.discord_webhook_cryo_url)
+	cryo.post_message("[mob_name] used a gamer word.")
+
+	// tell the caller we banned the mob
+	return TRUE
+
+/proc/check_for_troll(context, message, ban_me)
+	// ensure we've got gamer words
+	if(isemptylist(GLOB.gamer_words))
+		return FALSE
+	// ensure we've got a message
+	if(!istext(message))
+		return FALSE
+	// ensure we've got a client or mob
+	var/mob_name = "Unknown Gamer"
+	var/client/ban_client = null
+	if(istype(ban_me, /mob))
+		var/mob/M = ban_me
+		mob_name = "[M]"
+		ban_client = M.client
+	if(istype(ban_me, /client))
+		ban_client = ban_me
+	if(!ban_client)
+		return FALSE
+	// remove spaces and symbols from the message
+	var/regex/spaces = new(@"[\s]+", "ig")
+	var/regex/symbols = new(@"[\L]+", "ig")
+	var/check_me = spaces.Replace(message, "")
+	check_me = symbols.Replace(check_me, "")
+	// check the message for gamer words
+	for(var/word in GLOB.gamer_words)
+		if(findtext_char(check_me, word) > 0)
+			// tell the caller we kickban'd a troll
+			ban_and_kick_troll(context, message, word, mob_name, ban_client)
+			return TRUE
+	// nope, no gamer words found
+	return FALSE
+
+/proc/kick_troll(client/C)
+	spawn(1)
+		qdel(C)
+
+//------------------------------------------------------------------------------
+// end of troll.dm

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -457,6 +457,9 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 ## minimum number of players connected to the server before census bot will announce a new round (default 2)
 #CENSUS_BOT_MINIMUM 2
 
+## gamer words that invoke an automatic ban when used in messages
+#GAMER_WORDS qwertyuiop,asdfghjkl,zxcvbnm
+
 ## BYOND accounts younger than the value below will alert admins when they connect for the first time,
 ## as well as making the BYOND account age in player panel bold
 BYOND_ACCOUNT_AGE_THRESHOLD 7

--- a/paradise.dme
+++ b/paradise.dme
@@ -2504,6 +2504,7 @@
 #include "code\modules\world_topic\ping.dm"
 #include "code\modules\world_topic\players.dm"
 #include "code\modules\world_topic\status.dm"
+#include "code\scorpio\troll.dm"
 #include "code\shim\upstream_shim.dm"
 #include "goon\code\datums\browserOutput.dm"
 #include "interface\interface.dm"


### PR DESCRIPTION
## What Does This PR Do
Adds a configuration option `GAMER_WORDS` that allows a comma-separated list of [gamer words](https://www.urbandictionary.com/define.php?term=gamer%20word).
When a gamer uses a gamer word, they catch a swift and automatic ban. Closes #319 
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
* Trolls get banned swiftly and without fanfare.
* Admins don't have to waste time on trolls.

Note: Just 15 minutes ago, I logged into the server specifically to ban two gamers who decided to spam ahelps and radio with gamer words. I kinda wish that I had merged this yesterday. :smile:
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added system to ban trolls who use gamer words
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
