### PR TITLE
[Test Merge] - Pixel Shifting

### DIFF
--- a/code/modules/keybindings/bindings_mob.dm
+++ b/code/modules/keybindings/bindings_mob.dm
@@ -124,16 +124,28 @@
 	else if(client.keys_held["Ctrl"])
 		switch(SSinput.movement_keys[_key])
 			if(NORTH)
-				northface()
+				if(client.keys_held["Shift"])
+					northshift()
+				else
+					northface()
 				return
 			if(SOUTH)
-				southface()
+				if(client.keys_held["Shift"])
+					southshift()
+				else
+					southface()
 				return
 			if(WEST)
-				westface()
+				if(client.keys_held["Shift"])
+					westshift()
+				else
+					westface()
 				return
 			if(EAST)
-				eastface()
+				if(client.keys_held["Shift"])
+					eastshift()
+				else
+					eastface()
 				return
 	return ..()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -893,12 +893,6 @@
 
 	return loc_temp
 
-/mob/living/proc/get_standard_pixel_x_offset(lying = 0)
-	return initial(pixel_x)
-
-/mob/living/proc/get_standard_pixel_y_offset(lying = 0)
-	return initial(pixel_y)
-
 /mob/living/proc/spawn_dust()
 	new /obj/effect/decal/cleanable/ash(loc)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -955,6 +955,10 @@
 		return FALSE
 	if(AM.anchored || AM.throwing)
 		return FALSE
+	if(is_shifted)
+		pixel_x = initial(pixel_x)
+		pixel_y = initial(pixel_y)
+		is_shifted = FALSE
 	if(force < ((AM.move_resist / 2) * MOVE_FORCE_PULL_RATIO)) // DWARF mobs cannot pull uncooperative strong ones.
 		if(ismob(AM))
 			var/mob/M = AM

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -254,9 +254,9 @@
 
 /mob/living/proc/grabbedby(mob/living/carbon/user, supress_message = FALSE)
 	if(user == src || anchored)
-		return 0
+		return FALSE
 	if(!(status_flags & CANPUSH))
-		return 0
+		return FALSE
 
 	for(var/obj/item/grab/G in grabbed_by)
 		if(G.assailant == user)
@@ -267,7 +267,7 @@
 
 	var/obj/item/grab/G = new /obj/item/grab(user, src)
 	if(!G)	//the grab will delete itself in New if src is anchored
-		return 0
+		return FALSE
 	user.put_in_active_hand(G)
 	G.synch()
 	LAssailant = user
@@ -281,7 +281,6 @@
 	else*///This is an example of how you can make special types of grabs simply based on direction.
 	if(!supress_message)
 		visible_message("<span class='warning'>[user] has grabbed [src] passively!</span>")
-
 	return G
 
 /mob/living/attack_slime(mob/living/simple_animal/slime/M)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1075,35 +1075,49 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	set hidden = TRUE
 	return facedir(SOUTH)
 
+/mob/proc/canshift()
+	if(!canface() || pulling || pulledby)
+		return FALSE
+	var/turf/T = get_turf(src)
+	if(!T)
+		return FALSE
+	var/list/range = view(0, T)	// Same tile as usr
+	for(var/atom/A in range)
+		if(ismob(A))
+			var/mob/M = A
+			if(M != src)
+				return FALSE
+	return TRUE
+
 /mob/verb/eastshift()
 	set hidden = TRUE
-	if(!canface())
+	if(!canshift())
 		return FALSE
-	if(pixel_x <= 16)
+	if(pixel_x < 10)
 		pixel_x++
 		is_shifted = TRUE
 
 /mob/verb/westshift()
 	set hidden = TRUE
-	if(!canface())
+	if(!canshift())
 		return FALSE
-	if(pixel_x >= -16)
+	if(pixel_x > -10)
 		pixel_x--
 		is_shifted = TRUE
 
 /mob/verb/northshift()
 	set hidden = TRUE
-	if(!canface())
+	if(!canshift())
 		return FALSE
-	if(pixel_y <= 16)
+	if(pixel_y < 0)		//No vertical pixel-shifting, please
 		pixel_y++
 		is_shifted = TRUE
 
 /mob/verb/southshift()
 	set hidden = TRUE
-	if(!canface())
+	if(!canshift())
 		return FALSE
-	if(pixel_y >= -16)
+	if(pixel_y > 0)		//No vertical pixel-shifting, please
 		pixel_y--
 		is_shifted = TRUE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -548,17 +548,6 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 			client.screen = list()
 			hud_used.show_hud(hud_used.hud_version)
 
-/mob/setDir(new_dir)
-	if(forced_look)
-		if(isnum(forced_look))
-			dir = forced_look
-		else
-			var/atom/A = locateUID(forced_look)
-			if(istype(A))
-				dir = get_cardinal_dir(src, A)
-		return
-	. = ..()
-
 /mob/proc/show_inv(mob/user)
 	user.set_machine(src)
 	var/dat = {"<table>
@@ -1054,31 +1043,75 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 
 /mob/proc/facedir(ndir)
 	if(!canface())
-		return 0
+		return FALSE
 	setDir(ndir)
 	client.move_delay += movement_delay()
-	return 1
+	return TRUE
 
+/mob/setDir(new_dir)
+	if(forced_look)
+		if(isnum(forced_look))
+			dir = forced_look
+		else
+			var/atom/A = locateUID(forced_look)
+			if(istype(A))
+				dir = get_cardinal_dir(src, A)
+		return
+	. = ..()
 
 /mob/verb/eastface()
-	set hidden = 1
+	set hidden = TRUE
 	return facedir(EAST)
 
-
 /mob/verb/westface()
-	set hidden = 1
+	set hidden = TRUE
 	return facedir(WEST)
 
-
 /mob/verb/northface()
-	set hidden = 1
+	set hidden = TRUE
 	return facedir(NORTH)
 
-
 /mob/verb/southface()
-	set hidden = 1
+	set hidden = TRUE
 	return facedir(SOUTH)
 
+/mob/verb/eastshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_x <= 16)
+		pixel_x++
+		is_shifted = TRUE
+
+/mob/verb/westshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_x >= -16)
+		pixel_x--
+		is_shifted = TRUE
+
+/mob/verb/northshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_y <= 16)
+		pixel_y++
+		is_shifted = TRUE
+
+/mob/verb/southshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_y >= -16)
+		pixel_y--
+		is_shifted = TRUE
+
+/mob/proc/get_standard_pixel_x_offset(lying = 0)
+	return initial(pixel_x)
+
+/mob/proc/get_standard_pixel_y_offset(lying = 0)
+	return initial(pixel_y)
 
 /mob/proc/IsAdvancedToolUser()//This might need a rename but it should replace the can this mob use things check
 	return FALSE

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -50,6 +50,7 @@
 	var/med_record = ""
 	var/sec_record = ""
 	var/gen_record = ""
+	var/is_shifted = FALSE
 	var/lying = 0
 	var/lying_prev = 0
 	var/lastpuke = 0

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -411,7 +411,10 @@ GLOBAL_LIST_INIT(intents, list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM
 /mob/living/verb/lay_down()
 	set name = "Rest"
 	set category = "IC"
-
+	if(is_shifted)
+		pixel_x = initial(pixel_x)
+		pixel_y = initial(pixel_y)
+		is_shifted = FALSE
 	if(!resting)
 		client.move_delay = world.time + 20
 		to_chat(src, "<span class='notice'>You are now resting.</span>")

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -17,6 +17,11 @@
 			return TRUE
 	return (!mover.density || !density || lying)
 
+/mob/Moved()
+	if(is_shifted)
+		is_shifted = FALSE
+		pixel_x = get_standard_pixel_x_offset(lying)
+		pixel_y = get_standard_pixel_y_offset(lying)
 
 /client/verb/toggle_throw_mode()
 	set hidden = 1

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -1,12 +1,12 @@
-/mob/CanPass(atom/movable/mover, turf/target, height=0)
-	if(height==0)
-		return 1
+/mob/CanPass(atom/movable/mover, turf/target, height = 0)
+	if(height == 0)
+		return TRUE
 	if(istype(mover, /obj/item/projectile))
 		return (!density || lying)
 	if(mover.throwing)
 		return (!density || lying || (mover.throwing.thrower == src))
 	if(mover.checkpass(PASSMOB))
-		return 1
+		return TRUE
 	if(buckled == mover)
 		return TRUE
 	if(ismob(mover))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

- Allows for wholesome pixel shifting of mobs via ctrl+shift+directional arrow key press / WASD
- Ports code from Citadel Station 13's **monster860**
- Fixes Issue: #310 

## ALL CAPS, NO WHINING ABOUT ALL CAPS

- NO VERTICAL PIXEL SHIFTING
- YOU CAN SHIFT ONLY 10 PIXELS TO THE LEFT AND SHIFT ONLY 10 PIXELS TO THE RIGHT
- NO PIXEL SHIFTING WHEN ON THE SAME TILE AS OTHER MOBS
- NO PIXEL SHIFTING WHEN BEING PULLED
- NO PIXEL SHIFTING WHEN PULLING
- PULLING RESETS YOUR PIXEL SHIFT
- NO PIXEL SHIFTING WHEN RESTING
- RESTING RESETS YOUR PIXEL SHIFT

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
## Images of 10 pixels
![image](https://user-images.githubusercontent.com/69871346/104545688-a3020100-55f8-11eb-9074-6fa7c83c1451.png)
![image](https://user-images.githubusercontent.com/69871346/104545717-b614d100-55f8-11eb-8903-84d022a13d3d.png)
![image](https://user-images.githubusercontent.com/69871346/104545738-bd3bdf00-55f8-11eb-9ffd-10c50a819394.png)

## Video

https://user-images.githubusercontent.com/69871346/104545158-697cc600-55f7-11eb-8490-0022b6cf27ab.mp4

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Use Ctrl-Shift-direction key to shift your characters position. Only works for horizontal directions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
