### PR TITLE
Art Supplies Crate Redesigned

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1494,26 +1494,45 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	cost = 10
 	containername = "toner cartridges crate"
 
+
+/datum/supply_packs/misc/artscrafts
+	name = "Packaging, Paints, and Photos Crate"
+	contains = list(/obj/item/camera,
+					/obj/item/camera_film,
+					/obj/item/camera_film,
+					/obj/item/storage/photo_album,
+					/obj/item/stack/packageWrap,
+					/obj/item/reagent_containers/glass/paint/red,
+					/obj/item/reagent_containers/glass/paint/green,
+					/obj/item/reagent_containers/glass/paint/blue,
+					/obj/item/reagent_containers/glass/paint/yellow,
+					/obj/item/reagent_containers/glass/paint/violet,
+					/obj/item/reagent_containers/glass/paint/black,
+					/obj/item/reagent_containers/glass/paint/white,
+					/obj/item/reagent_containers/glass/paint/remover,
+					/obj/item/poster/random_official,
+					/obj/item/stack/wrapping_paper,
+					/obj/item/stack/wrapping_paper,
+					/obj/item/stack/wrapping_paper)
+	cost = 10
+	containername = "packaging paints photos crate"
+
 /datum/supply_packs/misc/artscrafts
 	name = "Arts and Crafts Supplies Crate"
 	contains = list(/obj/item/storage/fancy/crayons,
-	/obj/item/camera,
-	/obj/item/camera_film,
-	/obj/item/camera_film,
-	/obj/item/storage/photo_album,
-	/obj/item/stack/packageWrap,
-	/obj/item/reagent_containers/glass/paint/red,
-	/obj/item/reagent_containers/glass/paint/green,
-	/obj/item/reagent_containers/glass/paint/blue,
-	/obj/item/reagent_containers/glass/paint/yellow,
-	/obj/item/reagent_containers/glass/paint/violet,
-	/obj/item/reagent_containers/glass/paint/black,
-	/obj/item/reagent_containers/glass/paint/white,
-	/obj/item/reagent_containers/glass/paint/remover,
-	/obj/item/poster/random_official,
-	/obj/item/stack/wrapping_paper,
-	/obj/item/stack/wrapping_paper,
-	/obj/item/stack/wrapping_paper)
+					/obj/item/toy/crayon/spraycan,
+					/obj/item/toy/crayon/spraycan,
+					/obj/item/toy/crayon/spraycan,
+					/obj/structure/easel,
+					/obj/item/canvas,
+					/obj/item/canvas,
+					/obj/item/canvas/nineteenXnineteen,
+					/obj/item/canvas/nineteenXnineteen,
+					/obj/item/canvas/twentythreeXnineteen,
+					/obj/item/canvas/twentythreeXnineteen,
+					/obj/item/canvas/twentythreeXtwentythree,
+					/obj/item/canvas/twentythreeXtwentythree,
+					)
 	cost = 10
 	containername = "arts and crafts crate"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Renames the original "Arts and Crafts Supplies Crate" as "Packaging, Paints, and Photos Crates"
Adds new "Arts and Crafts Supplies Crate":
- 2 of each size canvas
- 3 Arksoft spray paint applicators
- 1 box of fancy crayons
- 1 easel

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Images of changes
![image](https://user-images.githubusercontent.com/69871346/104859818-d80e9c00-58f5-11eb-9709-62b0629be755.png)
_**Easel displayed separately.**_
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: "Packaging, Paints, and Photos Crate" supply crate
tweak: "Arts and Crafts Supplies Crate" supply crate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
