### PR TITLE
Robust Security Reserve

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -109,6 +109,7 @@
 	var/discord_webhook_arrivals_url = null
 	var/discord_webhook_cryo_url = null
 	var/discord_webhook_announcement_url = null
+	var/robust_security_reserve_role_id = null
 
 	var/overflow_server_url
 	var/forbid_singulo_possession = 0
@@ -552,6 +553,9 @@
 
 				if("discord_webhook_cryo_url")
 					config.discord_webhook_cryo_url = value
+
+				if("robust_security_reserve_role_id")
+					config.robust_security_reserve_role_id = value
 
 				if("donationsurl")
 					config.donationsurl = value

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -263,6 +263,9 @@ CHECK_RANDOMIZER
 ## Discord Webhook for Cryo notification
 # DISCORD_WEBHOOK_CRYO_URL https://discord.com/api/webhooks/7444...
 
+## Discord Role for @Robust Security Reserve
+# ROBUST_SECURITY_RESERVE_ROLE_ID 803125646...
+
 ## Donations address
 # DONATIONSURL http://example.org
 

--- a/tgui/packages/tgui/interfaces/KeycardAuth.js
+++ b/tgui/packages/tgui/interfaces/KeycardAuth.js
@@ -29,6 +29,13 @@ export const KeycardAuth = (props, context) => {
                     { 'triggerevent': 'Red Alert' })}
                   content="Red Alert" />
               </LabeledList.Item>
+              <LabeledList.Item label="Request Additional Security">
+                <Button
+                  icon="users"
+                  onClick={() => act('triggerevent',
+                    { 'triggerevent': 'Robust Security Reserve' })}
+                  content="Call Robust Security Reserve" />
+              </LabeledList.Item>
               <LabeledList.Item label="ERT">
                 <Button
                   icon="broadcast-tower"
@@ -82,6 +89,13 @@ export const KeycardAuth = (props, context) => {
           Fill out the reason for your ERT request.
         </Box>
       );
+    } else if (!data.hasSwiped && !data.rsrreason
+      && data.event === "Robust Security Reserve") {
+      swipeInfo = (
+        <Box color="red">
+          Fill out the reason for your Robust Security Reserve request.
+        </Box>
+      );
     } else if (data.hasConfirm) {
       swipeInfo = (
         <Box color="green">
@@ -120,6 +134,25 @@ export const KeycardAuth = (props, context) => {
                     : "-----"}
                   disabled={data.busy}
                   onClick={() => act('ert')}
+                />
+              </Box>
+            </Section>
+          )}
+          {data.event === 'Robust Security Reserve' && (
+            <Section title="Reason for Robust Security Reserve Call">
+              <Box>
+                <Button
+                  color={data.rsrreason
+                    ? ""
+                    : "red"}
+                  icon={data.rsrreason
+                    ? "check"
+                    : "pencil-alt"}
+                  content={data.rsrreason
+                    ? data.rsrreason
+                    : "-----"}
+                  disabled={data.busy}
+                  onClick={() => act('rsr')}
                 />
               </Box>
             </Section>


### PR DESCRIPTION
## What Does This PR Do
Adds a new option to Keycard Auth: Call Robust Security Reserve
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Two heads can now request additional security personnel be sent to the station.
Always useful when the :hankey: is hitting the fan due to traitors, vampires, or greytide.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
There is a `#role-sign-up` channel on the ScorpioStation Discord:
![role-sign-up](https://user-images.githubusercontent.com/1283521/105693818-d16bc000-5ec5-11eb-8450-c18cb2dc89ad.png)

After signing up for the `@Robust Security Reserve` role, the game will send a ping to the `#common-radio` channel when two heads swipe to call the Robust Security Reserve in game:
![dreamseeker_VqYwsQpwwu](https://user-images.githubusercontent.com/1283521/105694012-0f68e400-5ec6-11eb-93b4-4c7a221cf4fe.png)
![dreamseeker_RGrw1g1S32](https://user-images.githubusercontent.com/1283521/105694024-13950180-5ec6-11eb-9d14-948268b4c20c.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Added Robust Security Reserve option to Keycard Auth device.
/:cl:
