### PR TITLE
Add new Retirement subsystem

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -111,6 +111,9 @@
 	var/discord_webhook_announcement_url = null
 	var/robust_security_reserve_role_id = null
 
+	var/staff_retirement_warning_days = 30
+	var/staff_retirement_critical_days = 45
+
 	var/overflow_server_url
 	var/forbid_singulo_possession = 0
 
@@ -556,6 +559,12 @@
 
 				if("robust_security_reserve_role_id")
 					config.robust_security_reserve_role_id = value
+
+				if("staff_retirement_warning_days")
+					config.staff_retirement_warning_days = text2num(value)
+
+				if("staff_retirement_critical_days")
+					config.staff_retirement_critical_days = text2num(value)
 
 				if("donationsurl")
 					config.donationsurl = value

--- a/code/controllers/subsystem/retirement.dm
+++ b/code/controllers/subsystem/retirement.dm
@@ -17,9 +17,8 @@
 
 SUBSYSTEM_DEF(retirement)
 	flags = SS_NO_FIRE            // no need to fire this after initialization
-	init_order = INIT_ORDER_LAST  // as long as it's after INIT_ORDER_DBCORE...
+	init_order = INIT_ORDER_LAST  // messages are more visible at the end
 	name = "Retirement"
-	offline_implications = "No immediate action is needed."
 
 /datum/controller/subsystem/retirement/Initialize()
 	// ask the database about our staff
@@ -33,7 +32,7 @@ SUBSYSTEM_DEF(retirement)
 		INNER JOIN [format_table_name("player")] AS p
 			ON p.ckey = a.ckey
 		WHERE a.rank <> 'Removed'
-		ORDER BY days_ago desc"})
+		ORDER BY days_ago DESC"})
 
 	// if the query didn't work, better luck next time
 	if(!query.warn_execute())

--- a/code/controllers/subsystem/retirement.dm
+++ b/code/controllers/subsystem/retirement.dm
@@ -28,12 +28,12 @@ SUBSYSTEM_DEF(retirement)
 			a.ckey,
 			a.rank,
 			p.lastseen,
-			datediff(now(), p.lastseen) as days_ago
-		FROM [format_table_name("admin")] as a
-		INNER JOIN [format_table_name("player")] as p
-			on p.ckey = a.ckey
+			DATEDIFF(NOW(), p.lastseen) AS days_ago
+		FROM [format_table_name("admin")] AS a
+		INNER JOIN [format_table_name("player")] AS p
+			ON p.ckey = a.ckey
 		WHERE a.rank <> 'Removed'
-		order by days_ago desc"})
+		ORDER BY days_ago desc"})
 
 	// if the query didn't work, better luck next time
 	if(!query.warn_execute())

--- a/code/controllers/subsystem/retirement.dm
+++ b/code/controllers/subsystem/retirement.dm
@@ -1,0 +1,71 @@
+// retirement.dm
+// Copyright 2021 Patrick Meade.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+SUBSYSTEM_DEF(retirement)
+	flags = SS_NO_FIRE            // no need to fire this after initialization
+	init_order = INIT_ORDER_LAST  // as long as it's after INIT_ORDER_DBCORE...
+	name = "Retirement"
+	offline_implications = "No immediate action is needed."
+
+/datum/controller/subsystem/retirement/Initialize()
+	// ask the database about our staff
+	var/datum/db_query/query = SSdbcore.NewQuery({"
+		SELECT
+			a.ckey,
+			a.rank,
+			p.lastseen,
+			datediff(now(), p.lastseen) as days_ago
+		FROM [format_table_name("admin")] as a
+		INNER JOIN [format_table_name("player")] as p
+			on p.ckey = a.ckey
+		WHERE a.rank <> 'Removed'
+		order by days_ago desc"})
+
+	// if the query didn't work, better luck next time
+	if(!query.warn_execute())
+		qdel(query)
+		return
+
+	// while we still have rows to process
+	while(query.NextRow())
+		// read the row values into variables
+		var/ckey = query.item[1]
+		var/rank = query.item[2]
+		var/lastseen = query.item[3]
+		var/days_ago = text2num(query.item[4])
+
+		// if we're into active staff members, just stop processing rows
+		if(days_ago < config.staff_retirement_warning_days)
+			break
+
+		// if this person has been gone longer than the critical threshold
+		if(days_ago >= config.staff_retirement_critical_days)
+			log_and_message_admins("Staff member [ckey] ([rank]) was last seen on [lastseen] ([days_ago] days ago), retirement is recommended.")
+			continue
+
+		// if this person has been gone longer than the warning threshold
+		if(days_ago >= config.staff_retirement_warning_days)
+			log_and_message_admins("Staff member [ckey] ([rank]) was last seen on [lastseen] ([days_ago] days ago), reaching out to them is recommended.")
+
+	// all done with the query results
+	qdel(query)
+
+	// finish up successful initialization by returning whatever our parent returns
+	return ..()
+
+//------------------------------------------------------------------------------
+// end of retirement.dm

--- a/code/controllers/subsystem/retirement.dm
+++ b/code/controllers/subsystem/retirement.dm
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(retirement)
 	// if the query didn't work, better luck next time
 	if(!query.warn_execute())
 		qdel(query)
-		return
+		return ..()
 
 	// while we still have rows to process
 	while(query.NextRow())

--- a/code/controllers/subsystem/retirement.dm
+++ b/code/controllers/subsystem/retirement.dm
@@ -21,6 +21,10 @@ SUBSYSTEM_DEF(retirement)
 	name = "Retirement"
 
 /datum/controller/subsystem/retirement/Initialize()
+	// if we don't have a database, just bail
+	if(!SSdbcore.IsConnected())
+		return ..()
+
 	// ask the database about our staff
 	var/datum/db_query/query = SSdbcore.NewQuery({"
 		SELECT

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -266,6 +266,12 @@ CHECK_RANDOMIZER
 ## Discord Role for @Robust Security Reserve
 # ROBUST_SECURITY_RESERVE_ROLE_ID 803125646...
 
+## Retirement subsystem will recommend reaching out to staff absent for this many days
+# STAFF_RETIREMENT_WARNING_DAYS 30
+
+## Retirement subsystem will recommend retirement of staff absent for this many days
+# STAFF_RETIREMENT_CRITICAL_DAYS 45
+
 ## Donations address
 # DONATIONSURL http://example.org
 

--- a/paradise.dme
+++ b/paradise.dme
@@ -253,6 +253,7 @@
 #include "code\controllers\subsystem\persistence.dm"
 #include "code\controllers\subsystem\persistent_data.dm"
 #include "code\controllers\subsystem\radio.dm"
+#include "code\controllers\subsystem\retirement.dm"
 #include "code\controllers\subsystem\runechat.dm"
 #include "code\controllers\subsystem\shuttles.dm"
 #include "code\controllers\subsystem\sounds.dm"


### PR DESCRIPTION
## What Does This PR Do
Adds a new Retirement subsystem that indicates staff members approaching (or beyond) retirement policy when the server initializes.

Example log messages:
```text
[2021-01-26T09:03:36] ADMIN: INVALID/(INVALID) Staff member janedoe (Trial Admin) was last seen on 2020-11-29 18:00:00 (58 days ago), retirement is recommended.
[2021-01-26T09:03:36] ADMIN: INVALID/(INVALID) Staff member fredbloggs (Mentor) was last seen on 2020-12-20 18:00:00 (37 days ago), reaching out to them is recommended.
```
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Inactive staff happens. It's a volunteer effort, and people move on to different things with various levels of formality when they depart.
Inactive staff may mask a lack of active staff, hampering the efforts of existing staff to develop/run the game and recruit new staff.
This subsystem provides a reminder to active staff that inactive staff should be contacted and/or retired as appropriate.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Retirement subsystem
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
