### PR TITLE
Don't forget to allow movement processing

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -18,6 +18,7 @@
 	return (!mover.density || !density || lying)
 
 /mob/Moved()
+	. = ..()
 	if(is_shifted)
 		is_shifted = FALSE
 		pixel_x = get_standard_pixel_x_offset(lying)


### PR DESCRIPTION
## What Does This PR Do
Fixes "light sources aren't moving" bug introduced in #322 
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Light sources (and other movable atom tasks) should move.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed a bug where light sources weren't moving, amongst other movement effects
/:cl:
