### PR TITLE
Restore ERT and other shuttles to Emerald Z2

### DIFF
--- a/_maps/map_files/emerald/z2.dmm
+++ b/_maps/map_files/emerald/z2.dmm
@@ -9,11 +9,14 @@
 /turf/unsimulated/floor/snow,
 /area/syndicate_mothership)
 "ac" = (
-/obj/structure/flora/grass/brown,
-/turf/unsimulated/floor/snow,
+/turf/unsimulated/floor/snow{
+	dir = 8;
+	icon_state = "gravsnow_corner";
+	tag = "icon-gravsnow_corner (WEST)"
+	},
 /area/syndicate_mothership)
 "ad" = (
-/obj/structure/flora/bush,
+/obj/structure/flora/grass/brown,
 /turf/unsimulated/floor/snow,
 /area/syndicate_mothership)
 "ae" = (
@@ -29,12 +32,6 @@
 	tag = "icon-iron12"
 	},
 /area/space)
-"ag" = (
-/turf/unsimulated/floor/snow,
-/turf/unsimulated/floor/snow{
-	icon_state = "gravsnow_corner"
-	},
-/area/syndicate_mothership)
 "ah" = (
 /turf/unsimulated/wall{
 	icon_state = "iron14";
@@ -42,9 +39,10 @@
 	},
 /area/space)
 "ai" = (
-/obj/item/radio/intercom/syndicate{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/machinery/light/spot{
+	dir = 4;
+	icon_state = "tube1";
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -833,10 +831,11 @@
 	},
 /area/holodeck/source_basketball)
 "cr" = (
-/turf/unsimulated/floor{
-	name = "plating"
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall12"
 	},
-/area/space)
+/area/shuttle/transport)
 "cs" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/holofloor/grass,
@@ -971,13 +970,12 @@
 /turf/unsimulated/wall/fakeglass,
 /area/centcom/ferry)
 "cK" = (
-/obj/structure/flora/grass/brown,
-/turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
 	dir = 4;
 	icon_state = "gravsnow_corner";
 	tag = "icon-gravsnow_corner (EAST)"
 	},
+/turf/unsimulated/floor/snow,
 /area/syndicate_mothership)
 "cL" = (
 /turf/simulated/floor/holofloor{
@@ -1580,34 +1578,19 @@
 	icon_state = "cafeteria"
 	},
 /area/ninja/holding)
-"ef" = (
-/turf/unsimulated/floor/snow,
+"eh" = (
 /turf/simulated/shuttle/wall{
 	dir = 8;
 	icon_state = "diagonalWall3"
 	},
 /area/syndicate_mothership)
-"eg" = (
-/turf/unsimulated/floor/snow,
-/turf/simulated/shuttle/wall{
-	dir = 1;
-	icon_state = "diagonalWall3"
-	},
-/area/syndicate_mothership)
-"eh" = (
-/obj/structure/flora/tree/pine,
-/turf/unsimulated/floor/snow,
-/area/syndicate_mothership)
 "ei" = (
 /turf/space,
 /area/centcom/control)
 "ej" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "sit_away";
-	req_access_txt = "150"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
+/turf/simulated/shuttle/wall{
+	dir = 1;
+	icon_state = "diagonalWall3"
 	},
 /area/syndicate_mothership)
 "ek" = (
@@ -1658,15 +1641,13 @@
 	},
 /area/ninja/holding)
 "eq" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1;
+	icon_state = "propulsion_r";
+	tag = "icon-propulsion_r (NORTH)"
 	},
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
-	},
-/area/syndicate_mothership)
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate_sit)
 "er" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/holofloor{
@@ -1717,33 +1698,28 @@
 	icon_state = "cafeteria"
 	},
 /area/ninja/holding)
-"ex" = (
-/obj/item/flag/syndi,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
-	},
-/area/syndicate_mothership)
 "ey" = (
+/obj/structure/table/wood,
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "wood"
 	},
 /area/syndicate_mothership)
 "ez" = (
-/obj/item/radio/intercom/syndicate{
-	pixel_x = -28
-	},
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/bottle/rum,
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "wood"
 	},
 /area/syndicate_mothership)
 "eA" = (
-/turf/unsimulated/floor{
-	name = "plating"
+/turf/simulated/shuttle/wall{
+	dir = 8;
+	icon_state = "diagonalWall3"
 	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_sit)
 "eB" = (
 /turf/simulated/floor/holofloor{
 	dir = 10;
@@ -1865,36 +1841,27 @@
 	},
 /area/ninja/holding)
 "eT" = (
-/obj/machinery/light/spot{
+/obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+	icon_state = "propulsion";
+	tag = "icon-propulsion (NORTH)"
 	},
-/obj/machinery/computer/syndicate_depot/teleporter,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate_sit)
 "eU" = (
-/turf/unsimulated/wall/fakeglass{
+/obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "fakewindows";
-	tag = "icon-fakewindows (WEST)"
+	icon_state = "propulsion_l";
+	tag = "icon-propulsion_l (NORTH)"
 	},
-/area/syndicate_mothership)
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate_sit)
 "eV" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "sit_away";
-	name = "Syndicate Base";
-	width = 11
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "wall3"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_sit)
 "eW" = (
 /turf/unsimulated/wall{
 	icon_state = "iron13";
@@ -1915,18 +1882,14 @@
 	},
 /area/ninja/holding)
 "eZ" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "sst_away";
-	req_access_txt = "150"
+/turf/simulated/shuttle/wall{
+	dir = 1;
+	icon_state = "diagonalWall3"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_sit)
 "fa" = (
-/obj/effect/landmark{
-	name = "Syndicate-Spawn"
-	},
+/obj/structure/table/wood,
+/obj/item/syndicatedetonator,
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "wood"
@@ -1946,25 +1909,11 @@
 	},
 /area/ninja/holding)
 "fc" = (
-/obj/docking_port/stationary{
+/turf/simulated/shuttle/wall{
 	dir = 4;
-	dwidth = 7;
-	height = 5;
-	id = "sst_away";
-	name = "Syndicate Base";
-	width = 11
+	icon_state = "wall3"
 	},
-/turf/unsimulated/floor{
-	name = "plating"
-	},
-/area/syndicate_mothership)
-"fd" = (
-/obj/item/flag/syndi,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "wood"
-	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_elite)
 "fe" = (
 /obj/machinery/cryopod/right,
 /turf/unsimulated/floor{
@@ -1978,19 +1927,15 @@
 /turf/unsimulated/wall,
 /area/ninja/holding)
 "fh" = (
-/obj/structure/sign/double/map/left{
-	pixel_y = -32
-	},
-/obj/machinery/light,
-/obj/structure/rack/skeletal_bar/left,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "wood"
 	},
 /area/syndicate_mothership)
 "fi" = (
-/obj/machinery/computer/shuttle/syndicate/recall,
+/obj/effect/landmark{
+	name = "Syndicate-Spawn"
+	},
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "wood"
@@ -2109,6 +2054,19 @@
 	},
 /area/ninja/outpost)
 "fw" = (
+/obj/docking_port/mobile{
+	dir = 8;
+	dwidth = 4;
+	height = 11;
+	id = "trade_sol";
+	name = "sol trade shuttle";
+	roundstart_move = null;
+	width = 9
+	},
+/obj/machinery/door/airlock/shuttle/glass{
+	id_tag = "s_docking_airlock";
+	req_one_access_txt = "0"
+	},
 /obj/docking_port/stationary{
 	dir = 8;
 	dwidth = 4;
@@ -2117,8 +2075,8 @@
 	name = "docking bay 2 at Jupiter Station";
 	width = 9
 	},
-/turf/space,
-/area/space)
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
 "fx" = (
 /turf/unsimulated/floor{
 	dir = 8;
@@ -2182,14 +2140,11 @@
 	},
 /area/wizard_station)
 "fF" = (
-/obj/structure/flora/grass/brown,
-/turf/unsimulated/floor/snow,
-/turf/unsimulated/floor/snow{
-	dir = 10;
-	icon_state = "gravsnow_corner";
-	tag = "icon-gravsnow_corner (SOUTHWEST)"
+/turf/space,
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
 	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate)
 "fG" = (
 /obj/machinery/door/poddoor{
 	id_tag = "thunderdomeaxe";
@@ -2304,15 +2259,6 @@
 	icon_state = "wood"
 	},
 /area/wizard_station)
-"fV" = (
-/obj/structure/flora/tree/pine{
-	pixel_x = 1
-	},
-/turf/unsimulated/floor/snow,
-/turf/unsimulated/floor/snow{
-	icon_state = "gravsnow_corner"
-	},
-/area/syndicate_mothership)
 "fW" = (
 /obj/machinery/light/spot{
 	dir = 8;
@@ -2348,20 +2294,16 @@
 	},
 /area/trader_station/sol)
 "ga" = (
-/obj/machinery/light/spot{
+/turf/simulated/shuttle/wall{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+	icon_state = "diagonalWall3"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_elite)
 "gb" = (
 /obj/machinery/light/spot{
-	dir = 4;
+	dir = 1;
 	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	tag = "icon-tube1 (NORTH)"
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -2387,39 +2329,26 @@
 	icon_state = "grimy"
 	},
 /area/wizard_station)
-"ge" = (
-/turf/unsimulated/floor/snow,
-/turf/simulated/shuttle/wall{
-	icon_state = "diagonalWall3"
-	},
-/area/syndicate_mothership)
 "gf" = (
 /obj/item/camera,
 /turf/unsimulated/beach/sand,
 /area/ninja/holding)
 "gg" = (
-/obj/machinery/light/spot{
+/obj/structure/shuttle/engine/propulsion{
 	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+	icon_state = "propulsion_r";
+	tag = "icon-propulsion_r (NORTH)"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"gh" = (
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "diagonalWall3"
-	},
-/area/syndicate_mothership)
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate_elite)
 "gi" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
-/turf/simulated/floor/plating/airless,
-/area/syndicate_mothership)
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1;
+	icon_state = "propulsion";
+	tag = "icon-propulsion (NORTH)"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate_elite)
 "gj" = (
 /turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
@@ -2437,16 +2366,6 @@
 	icon_state = "wood"
 	},
 /area/wizard_station)
-"gm" = (
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "diagonalWall3";
-	tag = "icon-diagonalWall3"
-	},
-/area/syndicate_mothership)
 "gn" = (
 /obj/machinery/camera{
 	c_tag = "Thunderdome Arena";
@@ -2523,9 +2442,13 @@
 	},
 /area/wizard_station)
 "gx" = (
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plating/airless,
-/area/syndicate_mothership)
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1;
+	icon_state = "propulsion_l";
+	tag = "icon-propulsion_l (NORTH)"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate_elite)
 "gy" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/showcase,
@@ -2552,10 +2475,9 @@
 	},
 /area/ninja/outpost)
 "gB" = (
-/turf/unsimulated/floor/snow,
+/turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "diagonalWall3"
+	icon_state = "wall3"
 	},
 /area/syndicate_mothership)
 "gC" = (
@@ -2603,7 +2525,7 @@
 /turf/space/transit,
 /area/space)
 "gI" = (
-/obj/machinery/vending/syndisnack,
+/obj/machinery/vending/syndicigs,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -2725,7 +2647,7 @@
 	},
 /area/wizard_station)
 "gY" = (
-/obj/machinery/vending/syndicigs,
+/obj/machinery/vending/coffee/free,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -2754,18 +2676,11 @@
 /turf/space/transit,
 /area/space)
 "hb" = (
-/obj/docking_port/stationary{
-	area_type = /area/syndicate_mothership;
+/turf/simulated/shuttle/wall{
 	dir = 1;
-	dwidth = 13;
-	height = 21;
-	id = "emergency_syndicate";
-	name = "404 Not Found";
-	turf_type = /turf/unsimulated/floor/snow;
-	width = 31
+	icon_state = "diagonalWall3"
 	},
-/turf/unsimulated/floor/snow,
-/area/syndicate_mothership)
+/area/shuttle/syndicate_elite)
 "hc" = (
 /obj/docking_port/stationary/transit{
 	dir = 8;
@@ -2796,12 +2711,14 @@
 /turf/unsimulated/beach/coastline,
 /area/ninja/holding)
 "hg" = (
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/window/reinforced,
+/obj/structure/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "heater";
+	tag = "icon-heater (NORTH)"
 	},
-/turf/simulated/floor/plating/airless,
-/area/syndicate_mothership)
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate_sit)
 "hh" = (
 /obj/docking_port/stationary/transit{
 	dir = 1;
@@ -2813,50 +2730,21 @@
 	},
 /turf/space/transit,
 /area/space)
-"hi" = (
-/obj/machinery/porta_turret/syndicate/pod,
-/turf/simulated/floor/pod,
-/turf/space,
-/turf/simulated/shuttle/wall{
-	dir = 8;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/assault_pod)
-"hj" = (
-/turf/unsimulated/floor/snow,
-/turf/unsimulated/floor/snow{
-	dir = 4;
-	icon_state = "gravsnow_corner";
-	tag = "icon-gravsnow_corner (EAST)"
-	},
-/area/syndicate_mothership)
 "hk" = (
-/obj/machinery/porta_turret/syndicate/pod,
-/turf/simulated/floor/pod,
+/obj/effect/decal/warning_stripes/south,
 /turf/space,
-/turf/simulated/shuttle/wall{
-	dir = 1;
-	icon_state = "diagonalWall3"
-	},
-/area/shuttle/assault_pod)
+/turf/space,
+/turf/simulated/floor/plating/airless,
+/area/syndicate_mothership)
 "hl" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "syndicate_away";
-	req_access_txt = "150"
+/obj/structure/window/reinforced,
+/obj/structure/shuttle/engine/heater{
+	dir = 1;
+	icon_state = "heater";
+	tag = "icon-heater (NORTH)"
 	},
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
-	},
-/area/syndicate_mothership)
-"hm" = (
-/turf/unsimulated/floor/snow,
-/turf/unsimulated/floor/snow{
-	dir = 8;
-	icon_state = "gravsnow_corner";
-	tag = "icon-gravsnow_corner (WEST)"
-	},
-/area/syndicate_mothership)
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate_elite)
 "hn" = (
 /turf/unsimulated/floor{
 	dir = 2;
@@ -2864,9 +2752,10 @@
 	},
 /area/syndicate_mothership)
 "ho" = (
-/turf/unsimulated/wall/fakeglass{
-	dir = 1;
-	icon_state = "fakewindows"
+/turf/unsimulated/floor/snow{
+	dir = 4;
+	icon_state = "gravsnow_corner";
+	tag = "icon-gravsnow_corner (EAST)"
 	},
 /area/syndicate_mothership)
 "hp" = (
@@ -2880,45 +2769,19 @@
 	},
 /turf/space/transit/horizontal,
 /area/space)
-"hq" = (
-/turf/unsimulated/floor/snow,
-/turf/unsimulated/floor/snow{
-	dir = 6;
-	icon_state = "gravsnow_corner";
-	tag = "icon-gravsnow_corner (SOUTHEAST)"
-	},
-/area/syndicate_mothership)
-"hr" = (
-/turf/unsimulated/wall/fakeglass{
-	dir = 0;
-	icon_state = "fakewindows";
-	tag = "icon-fakewindows (EAST)"
-	},
-/area/syndicate_mothership)
 "hs" = (
-/turf/unsimulated/floor/snow,
 /turf/unsimulated/floor/snow{
-	dir = 10;
-	icon_state = "gravsnow_corner";
-	tag = "icon-gravsnow_corner (SOUTHWEST)"
-	},
-/area/syndicate_mothership)
-"ht" = (
-/obj/machinery/porta_turret/syndicate/pod,
-/turf/simulated/floor/pod,
-/turf/space,
-/turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "diagonalWall3";
-	tag = "icon-diagonalWall3"
-	},
-/area/shuttle/assault_pod)
-"hu" = (
-/turf/unsimulated/wall/fakeglass{
 	dir = 8;
-	icon_state = "fakewindows"
+	icon_state = "gravsnow_corner";
+	tag = "icon-gravsnow_corner (WEST)"
 	},
+/turf/unsimulated/floor/snow,
 /area/syndicate_mothership)
+"hu" = (
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate_sit)
 "hv" = (
 /turf/unsimulated/beach/water,
 /area/ninja/holding)
@@ -2927,41 +2790,24 @@
 /turf/unsimulated/beach/water,
 /area/ninja/holding)
 "hx" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
-"hy" = (
+"hz" = (
 /turf/unsimulated/wall/fakeglass{
-	dir = 4;
+	dir = 0;
 	icon_state = "fakewindows";
 	tag = "icon-fakewindows (EAST)"
 	},
 /area/syndicate_mothership)
-"hz" = (
-/turf/unsimulated/wall/fakeglass{
-	dir = 8;
-	icon_state = "fakewindows2";
-	tag = "icon-fakewindows2 (WEST)"
-	},
-/area/syndicate_mothership)
 "hA" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "Shuttle Dock"
+/obj/effect/decal/remains/human,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"hB" = (
-/obj/machinery/light{
-	dir = 1;
-	on = 1
-	},
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
-	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_sit)
 "hC" = (
 /obj/effect/spawner/window/reinforced,
 /turf/unsimulated/floor{
@@ -2969,24 +2815,17 @@
 	},
 /area/ninja/holding)
 "hD" = (
-/obj/machinery/light{
+/obj/machinery/sleeper/syndie{
 	dir = 4
 	},
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_elite)
 "hE" = (
-/turf/unsimulated/floor/snow,
-/turf/unsimulated/floor/snow{
-	icon_state = "gravsnow_corner"
-	},
-/turf/unsimulated/floor/snow{
-	dir = 1;
-	icon_state = "gravsnow_corner";
-	tag = "icon-gravsnow_corner (NORTH)"
-	},
+/turf/space,
+/turf/space,
+/turf/unsimulated/wall,
 /area/syndicate_mothership)
 "hF" = (
 /obj/effect/landmark{
@@ -2997,11 +2836,10 @@
 	},
 /area/ninja/holding)
 "hG" = (
-/obj/machinery/light{
-	dir = 1
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/turf/simulated/floor/plating/airless,
-/area/syndicate_mothership)
+/area/shuttle/syndicate_elite)
 "hH" = (
 /obj/machinery/vending/sovietsoda,
 /obj/machinery/light/small{
@@ -3010,11 +2848,11 @@
 /turf/simulated/floor/wood,
 /area/dynamic/source/lobby_russian)
 "hI" = (
-/turf/unsimulated/floor/snow,
-/turf/unsimulated/floor/snow{
-	dir = 1;
-	icon_state = "gravsnow_corner";
-	tag = "icon-gravsnow_corner (NORTH)"
+/turf/space,
+/turf/unsimulated/wall/fakeglass{
+	dir = 8;
+	icon_state = "fakewindows2";
+	tag = "icon-fakewindows2 (WEST)"
 	},
 /area/syndicate_mothership)
 "hJ" = (
@@ -3023,11 +2861,11 @@
 /turf/simulated/floor/wood,
 /area/dynamic/source/lobby_russian)
 "hK" = (
-/turf/unsimulated/floor/snow,
-/turf/unsimulated/floor/snow{
-	dir = 5;
-	icon_state = "gravsnow_corner";
-	tag = "icon-gravsnow_corner (NORTHEAST)"
+/turf/space,
+/turf/unsimulated/wall/fakeglass{
+	dir = 4;
+	icon_state = "fakewindows";
+	tag = "icon-fakewindows (EAST)"
 	},
 /area/syndicate_mothership)
 "hL" = (
@@ -3038,44 +2876,43 @@
 /turf/simulated/floor/wood,
 /area/dynamic/source/lobby_russian)
 "hM" = (
-/turf/unsimulated/wall/fakeglass{
-	dir = 8;
-	icon_state = "fakewindows3";
-	tag = "icon-fakewindows (WEST)"
+/turf/unsimulated/floor/snow{
+	dir = 6;
+	icon_state = "gravsnow_corner";
+	tag = "icon-gravsnow_corner (SOUTHEAST)"
 	},
 /area/syndicate_mothership)
 "hN" = (
-/obj/structure/sign/double/map/left{
-	pixel_y = 32
+/obj/machinery/sleeper/syndie,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_elite)
 "hO" = (
-/obj/machinery/washing_machine,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
+/obj/structure/flora/tree/pine,
+/turf/unsimulated/floor/snow,
 /area/syndicate_mothership)
 "hP" = (
-/obj/machinery/porta_turret/syndicate/pod,
-/turf/simulated/floor/pod,
+/turf/space,
 /turf/space,
 /turf/simulated/shuttle/wall{
-	dir = 4;
-	icon_state = "diagonalWall3"
+	icon_state = "wall3"
 	},
 /area/shuttle/assault_pod)
 "hQ" = (
-/obj/structure/table,
-/obj/item/storage/fancy/crayons,
-/obj/item/storage/fancy/crayons,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "freezerfloor"
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
 	},
-/area/syndicate_mothership)
+/obj/structure/window/reinforced,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate_sit)
 "hR" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/wood,
@@ -3110,18 +2947,11 @@
 /turf/simulated/floor/wood,
 /area/dynamic/source/lobby_russian)
 "hX" = (
-/obj/item/storage/fancy/crayons,
-/obj/machinery/light{
-	dir = 1;
-	on = 1
+/obj/structure/window/reinforced,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/obj/structure/table,
-/obj/item/storage/fancy/crayons,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "freezerfloor"
-	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_sit)
 "hY" = (
 /turf/simulated/floor/wood,
 /area/dynamic/source/lobby_disco)
@@ -3144,10 +2974,10 @@
 /turf/simulated/floor/light,
 /area/dynamic/source/lobby_disco)
 "ie" = (
-/obj/machinery/washing_machine,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "freezerfloor"
+/turf/unsimulated/wall/fakeglass{
+	dir = 8;
+	icon_state = "fakewindows3";
+	tag = "icon-fakewindows (WEST)"
 	},
 /area/syndicate_mothership)
 "if" = (
@@ -3165,100 +2995,90 @@
 /turf/unsimulated/wall,
 /area/wizard_station)
 "ii" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 2;
+	name = "Cell Door";
+	req_access_txt = "150"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate_sit)
+"ij" = (
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate_elite)
+"ik" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate_elite)
+"il" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal,
+/obj/item/clothing/glasses/welding,
+/obj/item/weldingtool,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate_sit)
+"im" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate_sit)
+"in" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate_elite)
+"io" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate_sit)
+"ip" = (
+/turf/unsimulated/floor/snow{
+	dir = 10;
+	icon_state = "gravsnow_corner";
+	tag = "icon-gravsnow_corner (SOUTHWEST)"
+	},
+/area/syndicate_mothership)
+"iq" = (
 /obj/machinery/computer/shuttle/syndicate/recall,
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
-"ij" = (
-/obj/item/radio/intercom/syndicate{
-	pixel_x = 0;
-	pixel_y = 25
-	},
-/obj/item/twohanded/required/kirbyplants,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
-	},
-/area/syndicate_mothership)
-"ik" = (
-/obj/machinery/vending/syndicigs,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
-	},
-/area/syndicate_mothership)
-"il" = (
-/obj/machinery/vending/syndisnack,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
-	},
-/area/syndicate_mothership)
-"im" = (
-/obj/structure/urinal{
-	pixel_y = 28
-	},
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "freezerfloor"
-	},
-/area/syndicate_mothership)
-"in" = (
-/obj/item/mop,
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/item/twohanded/required/kirbyplants,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "freezerfloor"
-	},
-/area/syndicate_mothership)
-"io" = (
-/obj/item/soap/syndie,
-/obj/structure/mopbucket,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "freezerfloor"
-	},
-/area/syndicate_mothership)
-"ip" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'FOURTH WALL'.";
-	name = "\improper FOURTH WALL";
-	pixel_x = -32
-	},
-/turf/unsimulated/floor/snow,
-/area/syndicate_mothership)
-"iq" = (
-/obj/structure/noticeboard{
-	pixel_x = -32
-	},
-/obj/item/paper/syndimemo,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
-	},
-/area/syndicate_mothership)
 "ir" = (
-/obj/structure/flora/bush,
-/turf/unsimulated/floor/snow,
-/turf/unsimulated/floor/snow{
-	dir = 1;
-	icon_state = "gravsnow_corner";
-	tag = "icon-gravsnow_corner (NORTH)"
-	},
+/turf/space,
+/turf/unsimulated/wall,
 /area/syndicate_mothership)
 "is" = (
-/mob/living/simple_animal/pet/dog/fox/Syndifox,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
+/turf/unsimulated/floor/snow{
+	icon_state = "gravsnow_corner"
 	},
 /area/syndicate_mothership)
 "it" = (
@@ -3266,15 +3086,10 @@
 	icon_state = "wall3"
 	},
 /area/syndicate_mothership)
-"iu" = (
-/obj/effect/decal/warning_stripes/southeast,
+"iv" = (
+/obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
-"iv" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
-/area/shuttle/assault_pod)
 "iw" = (
 /obj/structure/rack,
 /obj/item/clothing/under/plasmaman/wizard,
@@ -3298,32 +3113,131 @@
 	},
 /area/syndicate_mothership)
 "iz" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Restroom";
-	opacity = 1;
-	req_access_txt = "150"
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
 	},
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_elite)
 "iA" = (
+/obj/item/mop,
 /obj/structure/mirror{
 	pixel_x = 28
 	},
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
 "iB" = (
+/obj/structure/noticeboard{
+	pixel_x = -32
+	},
+/obj/item/paper/syndimemo,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
+"iC" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate_elite)
+"iD" = (
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate_sit)
+"iE" = (
+/obj/machinery/light/spot{
+	dir = 4;
+	icon_state = "tube1";
+	tag = "icon-tube1 (EAST)"
+	},
+/obj/structure/closet/syndicate/sst,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"iF" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Airlock";
+	req_access_txt = "150"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "syndicate_sit_1";
+	name = "Side Hull Door";
+	opacity = 0;
+	req_access_txt = "150"
+	},
+/obj/docking_port/mobile{
+	dir = 8;
+	dwidth = 3;
+	height = 5;
+	id = "sit";
+	name = "SIT shuttle";
+	roundstart_move = null;
+	width = 11
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door_control{
+	id = "syndicate_sit_1";
+	name = "Blast Doors";
+	pixel_x = 0;
+	pixel_y = -23;
+	req_access_txt = "150"
+	},
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 3;
+	height = 5;
+	id = "sit_away";
+	name = "Syndicate Base";
+	width = 11
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate_sit)
+"iG" = (
+/obj/effect/decal/warning_stripes/southwestcorner,
+/turf/simulated/floor/plating/airless,
+/area/syndicate_mothership)
+"iI" = (
+/obj/effect/decal/warning_stripes/southeastcorner,
+/turf/simulated/floor/plating/airless,
+/area/syndicate_mothership)
+"iJ" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "sit_away";
+	req_access_txt = "150"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"iK" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "sst_away";
+	req_access_txt = "150"
+	},
+/turf/unsimulated/floor{
+	name = "plating"
+	},
+/area/syndicate_mothership)
+"iL" = (
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
@@ -3333,7 +3247,7 @@
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
-"iC" = (
+"iM" = (
 /obj/structure/table/wood,
 /obj/item/pizzabox,
 /obj/item/paicard/syndicate,
@@ -3342,7 +3256,7 @@
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
-"iD" = (
+"iN" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/cans/beer{
 	pixel_x = -2;
@@ -3353,108 +3267,17 @@
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
-"iE" = (
-/obj/structure/closet/syndicate/sst,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"iF" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	dir = 8;
-	name = "Tactical Toilet";
-	opacity = 1;
-	req_access_txt = "150"
-	},
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "freezerfloor"
-	},
-/area/syndicate_mothership)
-"iG" = (
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plating/airless,
-/area/syndicate_mothership)
-"iH" = (
-/obj/structure/flora/tree/pine,
-/turf/unsimulated/floor/snow,
-/turf/unsimulated/floor/snow{
-	icon_state = "gravsnow_corner"
-	},
-/area/syndicate_mothership)
-"iI" = (
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plating/airless,
-/area/syndicate_mothership)
-"iJ" = (
-/obj/machinery/light{
-	dir = 1;
-	on = 1
-	},
-/turf/simulated/floor/plating/airless,
-/area/syndicate_mothership)
-"iK" = (
-/turf/unsimulated/wall/fakeglass{
-	dir = 9;
-	icon_state = "fakewindows";
-	tag = "icon-fakewindows (NORTHWEST)"
-	},
-/area/syndicate_mothership)
-"iL" = (
-/obj/item/twohanded/required/kirbyplants,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
-	},
-/area/syndicate_mothership)
-"iM" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/cans/beer{
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/obj/item/toy/cards/deck/syndicate{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
-	},
-/area/syndicate_mothership)
-"iN" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/mushroompizzaslice{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
-	},
-/area/syndicate_mothership)
 "iO" = (
-/obj/structure/flora/grass/brown,
+/turf/space,
 /turf/unsimulated/floor/snow,
-/turf/unsimulated/floor/snow{
-	icon_state = "gravsnow_corner"
-	},
 /area/syndicate_mothership)
 "iP" = (
-/obj/machinery/door/airlock/centcom{
-	aiControlDisabled = 1;
-	name = "Assault Pod";
-	opacity = 1;
-	req_one_access_txt = "150"
+/obj/effect/decal/warning_stripes/south,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/shuttle/assault_pod)
+/turf/simulated/floor/plating/airless,
+/area/syndicate_mothership)
 "iQ" = (
 /turf/unsimulated/floor{
 	icon_state = "dark";
@@ -3464,8 +3287,8 @@
 "iR" = (
 /turf/unsimulated/wall/fakeglass{
 	dir = 1;
-	icon_state = "fakewindows2";
-	tag = "icon-fakewindows2 (NORTH)"
+	icon_state = "fakewindows";
+	tag = "icon-fakewindows (WEST)"
 	},
 /area/syndicate_mothership)
 "iS" = (
@@ -3478,41 +3301,55 @@
 /turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
 "iU" = (
-/obj/machinery/door/poddoor{
-	id_tag = "nukeop_ready";
-	name = "Shuttle Dock Door"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"iV" = (
-/turf/simulated/floor/plating,
-/area/syndicate_mothership)
-"iW" = (
 /obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Airlock";
 	req_access_txt = "150"
 	},
-/turf/simulated/floor/plating,
-/area/syndicate_mothership)
-"iX" = (
-/obj/machinery/light,
-/turf/simulated/floor/plating,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "syndicate_elite";
+	name = "Side Hull Door";
+	opacity = 0;
+	req_access_txt = "150"
+	},
+/obj/docking_port/mobile{
+	dir = 4;
+	dwidth = 7;
+	height = 5;
+	id = "sst";
+	name = "SST shuttle";
+	roundstart_move = null;
+	width = 11
+	},
+/obj/structure/fans/tiny,
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 7;
+	height = 5;
+	id = "sst_away";
+	name = "Syndicate Base";
+	width = 11
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate_elite)
+"iW" = (
+/turf/unsimulated/wall/fakeglass{
+	dir = 8;
+	icon_state = "fakewindows";
+	tag = "icon-fakewindows (WEST)"
+	},
 /area/syndicate_mothership)
 "iY" = (
-/mob/living/simple_animal/pet/cat/Syndi,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_elite)
 "iZ" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "syndicate_away";
-	req_access_txt = "150"
-	},
 /turf/unsimulated/floor{
-	icon_state = "dark"
+	icon_state = "floor"
 	},
 /area/syndicate_mothership)
 "ja" = (
@@ -3526,10 +3363,9 @@
 /turf/simulated/floor/plasteel,
 /area/tdome/arena)
 "jd" = (
-/turf/unsimulated/wall/fakeglass{
-	dir = 8;
-	icon_state = "fakewindows";
-	tag = "icon-fakewindows (WEST)"
+/obj/machinery/light,
+/turf/unsimulated/floor{
+	icon_state = "floor"
 	},
 /area/syndicate_mothership)
 "je" = (
@@ -3538,16 +3374,59 @@
 	},
 /area/wizard_station)
 "jf" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/landmark{
-	name = "Syndicate-Spawn"
-	},
+/mob/living/simple_animal/pet/cat/Syndi,
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
 "jg" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate_sit)
+"jh" = (
+/obj/machinery/door_control{
+	id = "syndicate_sit_1";
+	name = "Shuttle Blast Doors";
+	pixel_x = -26;
+	pixel_y = -2;
+	req_access_txt = "150"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"ji" = (
+/obj/structure/sign/double/map/left{
+	pixel_y = 32
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"jj" = (
+/obj/machinery/light/small,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/assault_pod)
+"jl" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/shoes/brown,
+/obj/item/clothing/suit/armor/tdome/red,
+/obj/item/clothing/head/helmet/thunderdome,
+/obj/item/melee/energy/sword/saber/red,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/tdome/arena_source)
+"jm" = (
 /obj/machinery/door_control{
 	id = "nukeop_ready";
 	name = "Mission Launch Control";
@@ -3561,89 +3440,26 @@
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
-"jh" = (
-/obj/structure/sign/double/map/right{
-	pixel_y = 32
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"ji" = (
-/obj/machinery/door_control{
-	id = "syndicate_sit_1";
-	name = "Shuttle Blast Doors";
-	pixel_x = -26;
-	pixel_y = -2;
-	req_access_txt = "150"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"jj" = (
-/obj/machinery/computer/shuttle/syndicate/drop_pod,
-/turf/simulated/shuttle/wall{
-	icon_state = "wall3"
-	},
-/area/shuttle/assault_pod)
-"jk" = (
-/obj/structure/table/wood,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "wood"
-	},
-/area/syndicate_mothership)
-"jl" = (
-/obj/structure/rack,
-/obj/item/clothing/under/color/red,
-/obj/item/clothing/shoes/brown,
-/obj/item/clothing/suit/armor/tdome/red,
-/obj/item/clothing/head/helmet/thunderdome,
-/obj/item/melee/energy/sword/saber/red,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/tdome/arena_source)
-"jm" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/reagent_containers/food/drinks/bottle/rum,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "wood"
-	},
-/area/syndicate_mothership)
 "jn" = (
-/obj/structure/table/wood,
-/obj/item/syndicatedetonator,
+/obj/structure/chair/stool/bar,
+/obj/effect/landmark{
+	name = "Syndicate-Spawn"
+	},
 /turf/unsimulated/floor{
 	dir = 2;
-	icon_state = "wood"
+	icon_state = "bar"
 	},
 /area/syndicate_mothership)
 "jo" = (
-/obj/structure/table/wood,
-/obj/item/toy/nuke,
+/obj/item/twohanded/required/kirbyplants,
 /turf/unsimulated/floor{
 	dir = 2;
-	icon_state = "wood"
+	icon_state = "bar"
 	},
 /area/syndicate_mothership)
 "jp" = (
 /turf/simulated/floor/plasteel,
 /area/tdome/arena_source)
-"jq" = (
-/obj/machinery/light/spot{
-	dir = 4;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
-	},
-/obj/structure/closet/syndicate/sst,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
 "jr" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
@@ -3657,55 +3473,45 @@
 /area/tdome/arena_source)
 "js" = (
 /obj/structure/table/reinforced,
-/obj/item/syndicatedetonator,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "jt" = (
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1";
-	tag = "icon-bulb1 (EAST)"
+/obj/machinery/door_control{
+	id = "syndicate_elite";
+	name = "Shuttle Blast Doors";
+	pixel_x = 26;
+	pixel_y = -2;
+	req_access_txt = "150"
 	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
+/turf/unsimulated/floor{
+	icon_state = "dark"
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
-	},
-/area/shuttle/assault_pod)
-"ju" = (
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
 "jv" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
 "jw" = (
-/obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1";
-	tag = "icon-bulb1 (WEST)"
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
+/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/sst,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
-/area/shuttle/assault_pod)
+/area/shuttle/syndicate_elite)
 "jx" = (
+/obj/machinery/porta_turret/syndicate/pod,
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/assault_pod)
+"jy" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
-"jy" = (
-/obj/effect/decal/warning_stripes/northwestcorner,
-/turf/simulated/floor/plating/airless,
-/area/syndicate_mothership)
 "jz" = (
-/obj/machinery/light,
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plating/airless,
 /area/syndicate_mothership)
 "jA" = (
@@ -3729,27 +3535,13 @@
 	},
 /area/centcom/gamma)
 "jC" = (
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "sit_tele";
-	name = "Teleporter"
+/obj/machinery/computer/shuttle/sst,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_elite)
 "jD" = (
-/obj/structure/table/reinforced,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer{
-	pixel_y = 5
-	},
-/obj/item/healthupgrade{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/healthupgrade{
-	pixel_x = 6
-	},
+/obj/structure/closet/syndicate/sst,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -3766,32 +3558,26 @@
 /area/wizard_station)
 "jF" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/syndicate{
-	pixel_x = 5
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer{
+	pixel_y = 5
 	},
-/obj/item/multitool{
-	pixel_x = -7;
-	pixel_y = -1
+/obj/item/healthupgrade{
+	pixel_x = 6;
+	pixel_y = 5
 	},
-/obj/item/multitool,
+/obj/item/healthupgrade{
+	pixel_x = 6
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "jG" = (
-/obj/machinery/light/spot,
-/obj/structure/table/reinforced,
-/obj/item/radio/beacon/syndicate/bomb{
-	pixel_y = 8
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
 	},
-/obj/item/radio/beacon/syndicate/bomb{
-	pixel_y = 4
-	},
-/obj/item/radio/beacon/syndicate/bomb,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_sit)
 "jH" = (
 /obj/docking_port/mobile/emergency{
 	dir = 4;
@@ -3819,14 +3605,23 @@
 /turf/space,
 /area/adminconstruction)
 "jJ" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plating/airless,
-/area/syndicate_mothership)
+/obj/machinery/porta_turret/syndicate/pod,
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "diagonalWall3";
+	tag = "icon-diagonalWall3"
+	},
+/area/shuttle/assault_pod)
 "jK" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/light,
-/turf/simulated/floor/plating/airless,
-/area/syndicate_mothership)
+/obj/machinery/door/airlock/centcom{
+	aiControlDisabled = 1;
+	name = "Assault Pod";
+	opacity = 1;
+	req_one_access_txt = "150"
+	},
+/obj/docking_port/mobile/assault_pod,
+/turf/simulated/floor/plating,
+/area/shuttle/assault_pod)
 "jL" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/unsimulated/floor{
@@ -3835,11 +3630,8 @@
 	},
 /area/centcom/evac)
 "jM" = (
-/obj/machinery/door/window{
-	dir = 4;
-	name = "Uplink Management Control";
-	req_access_txt = "151"
-	},
+/obj/structure/table/wood,
+/obj/item/toy/nuke,
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "wood"
@@ -3853,11 +3645,11 @@
 	},
 /area/centcom/gamma)
 "jO" = (
-/obj/structure/sign/double/map/right{
-	pixel_y = -32
+/obj/machinery/door/window{
+	dir = 4;
+	name = "Uplink Management Control";
+	req_access_txt = "151"
 	},
-/obj/structure/rack/skeletal_bar/right,
-/obj/item/reagent_containers/food/drinks/bottle/gin,
 /turf/unsimulated/floor{
 	dir = 2;
 	icon_state = "wood"
@@ -3927,15 +3719,11 @@
 	},
 /area/abductor_ship)
 "kb" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Equipment Room";
-	req_access_txt = "150"
+/obj/machinery/computer/shuttle/sit,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
-	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_sit)
 "kc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
@@ -3999,46 +3787,55 @@
 /turf/space/transit/horizontal,
 /area/space)
 "kj" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Equipment Room";
+	req_access_txt = "150"
+	},
 /turf/unsimulated/floor{
 	dir = 2;
-	icon_state = "stage_stairs"
+	icon_state = "bar"
 	},
 /area/syndicate_mothership)
 "kk" = (
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "sst_tele";
-	name = "Teleporter"
+/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/sit,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_sit)
 "kl" = (
-/obj/machinery/vending/tool,
-/turf/unsimulated/floor{
-	icon_state = "dark";
-	tag = "icon-dark"
+/turf/simulated/shuttle/wall{
+	icon_state = "diagonalWall3"
 	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_elite)
 "km" = (
-/obj/machinery/door/airlock/centcom{
-	aiControlDisabled = 1;
-	name = "Assault Pod";
-	opacity = 1;
-	req_one_access_txt = "150"
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
 	},
-/obj/docking_port/mobile/assault_pod,
-/turf/simulated/floor/plating,
-/area/shuttle/assault_pod)
+/area/shuttle/syndicate_elite)
 "kn" = (
-/obj/machinery/sleeper/syndie{
-	dir = 2;
-	icon_state = "sleeper_s-open"
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Airlock";
+	req_access_txt = "150"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
+/obj/machinery/door_control{
+	id = "syndicate_elite";
+	name = "Blast Doors";
+	pixel_x = -25;
+	pixel_y = 0;
+	req_access_txt = "150"
 	},
-/area/syndicate_mothership)
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "syndicate_elite";
+	name = "Front Hull Door";
+	opacity = 0;
+	req_access_txt = "150"
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate_elite)
 "ko" = (
 /obj/machinery/computer/shuttle/admin,
 /turf/unsimulated/floor{
@@ -4046,19 +3843,11 @@
 	},
 /area/centcom/evac)
 "kp" = (
-/obj/machinery/light/spot{
-	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "diagonalWall3"
 	},
-/obj/machinery/sleeper/syndie{
-	dir = 2;
-	icon_state = "sleeper_s-open"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_elite)
 "kq" = (
 /turf/unsimulated/floor{
 	icon_state = "dark";
@@ -4071,13 +3860,9 @@
 	},
 /area/syndicate_mothership)
 "ks" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
 /turf/unsimulated/floor{
-	icon_state = "dark";
-	tag = "icon-dark"
+	dir = 2;
+	icon_state = "stage_stairs"
 	},
 /area/syndicate_mothership)
 "kt" = (
@@ -4125,12 +3910,10 @@
 /turf/simulated/floor/bluegrid,
 /area/tdome/arena_source)
 "kC" = (
-/obj/structure/chair/stool,
-/turf/unsimulated/floor{
-	icon_state = "dark";
-	tag = "icon-dark"
+/turf/simulated/shuttle/wall{
+	icon_state = "diagonalWall3"
 	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_sit)
 "kD" = (
 /obj/machinery/computer/camera_advanced/abductor{
 	team = 4
@@ -4161,27 +3944,37 @@
 /turf/unsimulated/floor/abductor,
 /area/abductor_ship)
 "kJ" = (
-/obj/structure/closet/syndicate/personal,
-/turf/unsimulated/floor{
-	dir = 8;
-	icon_state = "vault"
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Airlock";
+	req_access_txt = "150"
 	},
-/area/syndicate_mothership)
+/obj/machinery/door_control{
+	id = "syndicate_sit_1";
+	name = "Blast Doors";
+	pixel_x = -25;
+	pixel_y = 0;
+	req_access_txt = "150"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "syndicate_sit_1";
+	name = "Front Hull Door";
+	opacity = 0;
+	req_access_txt = "150"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate_sit)
 "kK" = (
-/obj/structure/table,
-/obj/item/storage/fancy/crayons,
-/obj/machinery/light/spot{
-	dir = 1;
-	icon_state = "tube1";
-	tag = "icon-tube1 (NORTH)"
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "diagonalWall3"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
+/area/shuttle/syndicate_sit)
 "kL" = (
-/obj/structure/table,
-/obj/item/gun/energy/ionrifle,
+/obj/structure/chair/stool,
 /turf/unsimulated/floor{
 	icon_state = "dark";
 	tag = "icon-dark"
@@ -4227,12 +4020,9 @@
 	},
 /area/abductor_ship)
 "kT" = (
-/obj/effect/landmark{
-	name = "Syndicate-Infiltrator";
-	tag = "Commando"
-	},
-/obj/structure/mirror{
-	pixel_x = -28
+/obj/machinery/sleeper/syndie{
+	dir = 2;
+	icon_state = "sleeper_s-open"
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -4336,8 +4126,9 @@
 	},
 /area/centcom/control)
 "lg" = (
-/obj/structure/mirror{
-	pixel_x = 28
+/obj/item/radio/intercom/syndicate{
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -4824,7 +4615,10 @@
 	},
 /area/centcom/control)
 "mv" = (
-/obj/machinery/light/spot,
+/obj/item/radio/intercom/syndicate{
+	pixel_x = -32;
+	pixel_y = 0
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -4899,6 +4693,34 @@
 	icon_state = "bar"
 	},
 /area/centcom/control)
+"mF" = (
+/obj/structure/table,
+/obj/item/grenade/syndieminibomb{
+	pixel_x = 4;
+	pixel_y = 2;
+	pixel_z = 0
+	},
+/obj/item/grenade/syndieminibomb{
+	pixel_x = -1
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"mG" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_r";
+	tag = "icon-propulsion_r (EAST)"
+	},
+/turf/space,
+/area/shuttle/administration)
+"mH" = (
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "wall3"
+	},
+/area/shuttle/syndicate)
 "mI" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/unsimulated/floor{
@@ -5175,36 +4997,26 @@
 	},
 /area/syndicate_mothership)
 "nr" = (
-/obj/item/radio/intercom/syndicate{
-	pixel_x = -32;
-	pixel_y = 0
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "ns" = (
-/obj/machinery/door_control{
-	id = "syndicate_elite";
-	name = "Shuttle Blast Doors";
-	pixel_x = 26;
-	pixel_y = -2;
-	req_access_txt = "150"
+/obj/structure/sign/double/map/right{
+	pixel_y = 32
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "nt" = (
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/obj/effect/landmark{
-	name = "Syndicate-Infiltrator";
-	tag = "Commando"
-	},
 /turf/unsimulated/floor{
-	icon_state = "dark"
+	name = "plating"
 	},
 /area/syndicate_mothership)
 "nu" = (
@@ -5222,18 +5034,8 @@
 	},
 /area/centcom/control)
 "nv" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/syndicate{
-	pixel_x = 5
-	},
-/obj/item/clothing/head/welding{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
+/turf/simulated/floor/plating/airless,
+/area/shuttle/syndicate_elite)
 "nw" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Communications Office";
@@ -5245,12 +5047,15 @@
 	},
 /area/centcom/control)
 "nx" = (
-/obj/machinery/door/airlock/hatch/syndicate/command,
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "commandcenter"
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id_tag = "commandcenter";
+	name = "Privacy Shutters"
 	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
+/turf/unsimulated/wall/fakeglass{
+	dir = 8;
+	icon_state = "fakewindows3";
+	tag = "icon-fakewindows (WEST)"
 	},
 /area/syndicate_mothership)
 "ny" = (
@@ -5276,15 +5081,12 @@
 	},
 /area/centcom/control)
 "nB" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2;
-	id_tag = "commandcenter";
-	name = "Privacy Shutters"
+/obj/machinery/door/window/northleft{
+	name = "Out";
+	req_access_txt = "150"
 	},
-/turf/unsimulated/wall/fakeglass{
-	dir = 8;
-	icon_state = "fakewindows3";
-	tag = "icon-fakewindows (WEST)"
+/turf/unsimulated/floor{
+	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "nC" = (
@@ -5306,9 +5108,8 @@
 	},
 /area/centcom/control)
 "nF" = (
-/obj/machinery/computer/shuttle/sit,
-/turf/unsimulated/floor{
-	icon_state = "dark"
+/turf/simulated/shuttle/wall{
+	icon_state = "diagonalWall3"
 	},
 /area/syndicate_mothership)
 "nG" = (
@@ -5324,23 +5125,9 @@
 	},
 /area/centcom/control)
 "nI" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "sit_ready";
-	name = "SIT Base Access";
-	pixel_x = -6;
-	pixel_y = 6;
-	req_access_txt = "153"
-	},
-/obj/machinery/door_control{
-	id = "sit_tele";
-	name = "SIT Teleporter Access";
-	pixel_x = 6;
-	pixel_y = 6;
-	req_access_txt = "153"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "diagonalWall3"
 	},
 /area/syndicate_mothership)
 "nJ" = (
@@ -5369,43 +5156,21 @@
 	},
 /area/centcom/specops)
 "nL" = (
-/obj/machinery/computer/shuttle/sst,
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/obj/machinery/computer/syndicate_depot/teleporter,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "nM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door_control{
-	id = "sst_armory";
-	name = "SST Extra Weapons";
-	pixel_x = -6;
-	pixel_y = -4;
-	req_access_txt = "153"
-	},
-/obj/machinery/door_control{
-	id = "sst_ready";
-	name = "SST Base Access";
-	pixel_x = -6;
-	pixel_y = 6;
-	req_access_txt = "153"
-	},
-/obj/machinery/door_control{
-	id = "sst_tele";
-	name = "SST Teleporter Access";
-	pixel_x = 6;
-	pixel_y = 6;
-	req_access_txt = "153"
-	},
-/obj/machinery/door_control{
-	id = "sst_mechbay";
-	name = "SST Mech Bay";
-	pixel_x = 6;
-	pixel_y = -4;
-	req_access_txt = "153"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "diagonalWall3";
+	tag = "icon-diagonalWall3"
 	},
 /area/syndicate_mothership)
 "nN" = (
@@ -5430,12 +5195,9 @@
 	},
 /area/centcom/specops)
 "nP" = (
-/obj/machinery/mech_bay_recharge_port/upgraded/unsimulated{
-	dir = 8;
-	icon_state = "recharge_port"
-	},
+/obj/machinery/light/spot,
 /turf/unsimulated/floor{
-	name = "plating"
+	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "nQ" = (
@@ -5459,8 +5221,10 @@
 	},
 /area/centcom/specops)
 "nS" = (
-/obj/mecha/combat/marauder/mauler/loaded,
-/obj/effect/decal/warning_stripes/red/hollow,
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "sit_tele";
+	name = "Teleporter"
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -5488,7 +5252,10 @@
 	},
 /area/shuttle/escape)
 "nW" = (
-/obj/effect/decal/warning_stripes/blue,
+/obj/machinery/door/window/northright{
+	name = "In";
+	req_access_txt = "150"
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -5508,8 +5275,14 @@
 	},
 /area/centcom/evac)
 "nY" = (
-/turf/space,
-/area/centcom/evac)
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "sst_tele";
+	name = "Teleporter"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
 "nZ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
@@ -5540,9 +5313,8 @@
 	},
 /area/centcom/evac)
 "ob" = (
-/obj/effect/landmark{
-	name = "Syndicate-Infiltrator-Leader";
-	tag = "Commando"
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Shuttle Dock"
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -5750,23 +5522,18 @@
 	},
 /area/shuttle/gamma/space)
 "oz" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
+/obj/machinery/computer/shuttle/sit,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "oA" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 8;
-	id_tag = "commandcenter";
-	name = "Privacy Shutters"
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "commandcenter"
 	},
-/turf/unsimulated/wall/fakeglass{
-	dir = 8;
-	icon_state = "fakewindows3";
-	tag = "icon-fakewindows (WEST)"
+/obj/machinery/door/airlock/hatch/syndicate/command,
+/turf/unsimulated/floor{
+	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "oB" = (
@@ -5840,6 +5607,13 @@
 	icon_state = "vault"
 	},
 /area/centcom/specops)
+"oI" = (
+/turf/space,
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/syndicate)
 "oJ" = (
 /obj/structure/closet/secure_closet/guncabinet,
 /obj/item/ammo_box/magazine/m10mm,
@@ -5890,6 +5664,18 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"oO" = (
+/turf/unsimulated/wall/fakeglass{
+	dir = 8;
+	icon_state = "fakewindows"
+	},
+/area/syndicate_mothership)
+"oP" = (
+/obj/machinery/computer/shuttle/syndicate,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "oQ" = (
 /turf/simulated/shuttle/wall{
 	dir = 2;
@@ -6121,6 +5907,13 @@
 	name = "grass"
 	},
 /area/centcom/specops)
+"pn" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall_f5";
+	tag = "icon-swall_f5"
+	},
+/area/shuttle/supply)
 "po" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -6135,6 +5928,16 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/gamma/space)
+"pp" = (
+/obj/item/storage/fancy/cigarettes/dromedaryco,
+/obj/item/lighter/zippo{
+	pixel_x = 5
+	},
+/obj/structure/table,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
 "pq" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -6151,6 +5954,17 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/gamma/space)
+"pr" = (
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
+	},
+/obj/machinery/vending/tool,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
 "pt" = (
 /obj/machinery/door/airlock/shuttle{
 	req_access_txt = "0"
@@ -6204,15 +6018,11 @@
 	icon_state = "swall_s9"
 	},
 /area/shuttle/gamma/space)
-"pz" = (
-/turf/unsimulated/floor{
-	icon_state = "floor"
-	},
-/area/syndicate_mothership)
 "pA" = (
-/obj/machinery/light,
-/turf/unsimulated/floor{
-	icon_state = "floor"
+/turf/unsimulated/wall/fakeglass{
+	dir = 8;
+	icon_state = "fakewindows2";
+	tag = "icon-fakewindows2 (WEST)"
 	},
 /area/syndicate_mothership)
 "pB" = (
@@ -6253,7 +6063,11 @@
 	},
 /area/centcom/specops)
 "pF" = (
-/turf/unsimulated/wall/fakeglass,
+/turf/unsimulated/wall/fakeglass{
+	dir = 1;
+	icon_state = "fakewindows2";
+	tag = "icon-fakewindows2 (NORTH)"
+	},
 /area/syndicate_mothership)
 "pG" = (
 /turf/unsimulated/floor{
@@ -6519,6 +6333,16 @@
 	icon_state = "carpetside"
 	},
 /area/centcom/specops)
+"qi" = (
+/obj/machinery/door/window{
+	dir = 4;
+	name = "Equipment Room";
+	req_access_txt = "150"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "qj" = (
 /turf/unsimulated/wall/fakeglass{
 	dir = 1;
@@ -6568,6 +6392,11 @@
 	name = "bookcase (Reports)"
 	},
 /area/centcom/specops)
+"qn" = (
+/obj/structure/grille,
+/obj/structure/shuttle/window,
+/turf/simulated/shuttle/plating,
+/area/shuttle/transport)
 "qo" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -6585,6 +6414,14 @@
 	icon_state = "green"
 	},
 /area/centcom/control)
+"qs" = (
+/obj/machinery/sleeper/upgraded{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
 "qu" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Bathroom";
@@ -6596,6 +6433,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/centcom/specops)
+"qv" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/simulated/shuttle/plating,
+/area/shuttle/supply)
 "qw" = (
 /obj/machinery/door/airlock/centcom{
 	name = "General Access";
@@ -6695,11 +6539,30 @@
 	},
 /area/centcom/bathroom)
 "qF" = (
-/turf/simulated/floor/mech_bay_recharge_floor,
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	id_tag = "commandcenter";
+	name = "Privacy Shutters"
+	},
+/turf/unsimulated/wall/fakeglass{
+	dir = 8;
+	icon_state = "fakewindows3";
+	tag = "icon-fakewindows (WEST)"
+	},
 /area/syndicate_mothership)
 "qG" = (
-/obj/machinery/computer/mech_bay_power_console,
-/turf/unsimulated/floor,
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/obj/machinery/sleeper/syndie{
+	dir = 2;
+	icon_state = "sleeper_s-open"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
 /area/syndicate_mothership)
 "qH" = (
 /turf/unsimulated/floor{
@@ -6855,6 +6718,21 @@
 	},
 /area/centcom)
 "rb" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Hatch";
+	req_access_txt = "109"
+	},
+/obj/docking_port/mobile{
+	dir = 8;
+	dwidth = 2;
+	height = 11;
+	id = "specops";
+	name = "ert shuttle";
+	roundstart_move = null;
+	width = 5
+	},
+/obj/structure/fans/tiny,
 /obj/docking_port/stationary{
 	dir = 8;
 	dwidth = 2;
@@ -6863,8 +6741,8 @@
 	name = "centcom bay 3";
 	width = 5
 	},
-/turf/space,
-/area/space)
+/turf/simulated/shuttle/plating,
+/area/shuttle/specops)
 "rc" = (
 /obj/effect/decal/cleanable/blood,
 /turf/unsimulated/floor{
@@ -7017,6 +6895,13 @@
 	name = "grass"
 	},
 /area/centcom/evac)
+"rt" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
 "ru" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/unsimulated/floor{
@@ -7702,6 +7587,18 @@
 	},
 /area/tdome/tdomeobserve)
 "tb" = (
+/obj/machinery/door/airlock/shuttle{
+	id_tag = "s_docking_airlock"
+	},
+/obj/docking_port/mobile{
+	dir = 8;
+	dwidth = 2;
+	height = 12;
+	id = "ferry";
+	name = "ferry shuttle";
+	roundstart_move = null;
+	width = 5
+	},
 /obj/docking_port/stationary{
 	dir = 8;
 	dwidth = 2;
@@ -7710,8 +7607,8 @@
 	name = "centcom bay 2";
 	width = 5
 	},
-/turf/space,
-/area/space)
+/turf/simulated/shuttle/floor,
+/area/shuttle/transport)
 "tc" = (
 /turf/unsimulated/floor{
 	dir = 4;
@@ -7883,6 +7780,51 @@
 	tag = "icon-redbluefull (WEST)"
 	},
 /area/tdome/tdomeobserve)
+"tv" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	damage_deflection = 75;
+	id_tag = "syndicate_jail";
+	locked = 1;
+	name = "Syndicate Jail"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"tw" = (
+/obj/machinery/light{
+	dir = 1;
+	on = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/syndicate_mothership)
+"ty" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "open";
+	id_tag = "voxshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 4;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_end";
+	tag = "icon-window5_end (EAST)"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"tA" = (
+/obj/machinery/light/spot,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
 "tB" = (
 /turf/unsimulated/wall/fakeglass{
 	dir = 8;
@@ -7904,6 +7846,10 @@
 	tag = "icon-fakewindows (EAST)"
 	},
 /area/tdome)
+"tE" = (
+/obj/structure/AIcore,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
 "tF" = (
 /obj/structure/table,
 /obj/item/storage/lockbox{
@@ -7922,6 +7868,21 @@
 	},
 /area/tdome/arena)
 "tH" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Hatch";
+	req_access_txt = "106"
+	},
+/obj/docking_port/mobile{
+	dir = 2;
+	dwidth = 8;
+	height = 15;
+	id = "admin";
+	name = "administration shuttle";
+	roundstart_move = null;
+	timid = 1;
+	width = 18
+	},
 /obj/docking_port/stationary{
 	dir = 2;
 	dwidth = 9;
@@ -7931,8 +7892,10 @@
 	timid = 1;
 	width = 19
 	},
-/turf/space,
-/area/space)
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
 "tI" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle{
@@ -8073,6 +8036,12 @@
 	},
 /area/tdome/arena)
 "tW" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Hatch";
+	req_access_txt = "31"
+	},
+/obj/docking_port/mobile/supply,
 /obj/docking_port/stationary{
 	dir = 8;
 	dwidth = 5;
@@ -8081,8 +8050,8 @@
 	name = "supply centcom";
 	width = 12
 	},
-/turf/space,
-/area/space)
+/turf/simulated/shuttle/floor,
+/area/shuttle/supply)
 "tX" = (
 /turf/unsimulated/floor{
 	dir = 5;
@@ -10648,6 +10617,14 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/trader_station/sol)
+"yE" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Hatch";
+	req_access_txt = "31"
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/supply)
 "yF" = (
 /turf/unsimulated/floor{
 	icon_state = "floor";
@@ -10918,6 +10895,19 @@
 	icon_state = "fakewindows2"
 	},
 /area/trader_station/sol)
+"zo" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall_f10"
+	},
+/area/shuttle/transport)
+"zp" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/specops)
 "zr" = (
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -11046,6 +11036,11 @@
 	tag = "icon-fakewindows (EAST)"
 	},
 /area/trader_station/sol)
+"zG" = (
+/obj/effect/spawner/lootdrop/trade_sol/eng,
+/obj/structure/closet,
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
 "zH" = (
 /obj/machinery/vending/cola,
 /turf/simulated/shuttle/floor,
@@ -11077,7 +11072,13 @@
 	},
 /area/admin)
 "zL" = (
-/obj/item/flag/syndi,
+/obj/structure/table,
+/obj/item/storage/fancy/crayons,
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -11093,15 +11094,12 @@
 	},
 /area/admin)
 "zN" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 4;
-	id_tag = "commandcenter";
-	name = "Privacy Shutters"
+/obj/machinery/door/airlock/hatch/syndicate/command,
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "commandcenter"
 	},
-/turf/unsimulated/wall/fakeglass{
-	dir = 8;
-	icon_state = "fakewindows3";
-	tag = "icon-fakewindows (WEST)"
+/turf/unsimulated/floor{
+	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "zO" = (
@@ -11141,6 +11139,24 @@
 	},
 /area/trader_station/sol)
 "zT" = (
+/obj/machinery/door/airlock/hatch{
+	frequency = 1331;
+	icon_state = "door_locked";
+	id_tag = "vox_northeast_lock";
+	locked = 1;
+	req_access_txt = "152";
+	req_one_access = null;
+	req_one_access_txt = "0"
+	},
+/obj/docking_port/mobile{
+	dir = 2;
+	dwidth = 2;
+	height = 18;
+	id = "skipjack";
+	name = "Vox Skipjack";
+	roundstart_move = null;
+	width = 19
+	},
 /obj/docking_port/stationary{
 	dir = 2;
 	dwidth = 2;
@@ -11149,8 +11165,8 @@
 	name = "vox bay 1";
 	width = 19
 	},
-/turf/space,
-/area/space)
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
 "zU" = (
 /obj/machinery/door/window/southleft{
 	name = "Cell B";
@@ -11399,6 +11415,14 @@
 "Aw" = (
 /turf/unsimulated/wall,
 /area/centcom)
+"Ax" = (
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/supply)
 "Ay" = (
 /obj/structure/table/reinforced,
 /obj/item/melee/classic_baton/telescopic,
@@ -11617,45 +11641,73 @@
 	},
 /area/admin)
 "AX" = (
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "commandcenter"
+/obj/machinery/door/poddoor/shutters{
+	dir = 8;
+	id_tag = "commandcenter";
+	name = "Privacy Shutters"
 	},
-/obj/machinery/door/airlock/hatch/syndicate/command,
-/turf/unsimulated/floor{
-	icon_state = "dark"
+/turf/unsimulated/wall/fakeglass{
+	dir = 8;
+	icon_state = "fakewindows3";
+	tag = "icon-fakewindows (WEST)"
 	},
 /area/syndicate_mothership)
 "AY" = (
-/obj/machinery/light/spot{
-	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
-	},
-/obj/machinery/pdapainter,
+/obj/machinery/washing_machine,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "AZ" = (
-/obj/structure/table,
-/obj/machinery/light/spot{
-	dir = 4;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "sit_ready";
+	name = "SIT Base Access";
+	pixel_x = -6;
+	pixel_y = 6;
+	req_access_txt = "153"
 	},
-/obj/item/storage/backpack/satchel,
-/obj/item/storage/backpack/satchel,
+/obj/machinery/door_control{
+	id = "sit_tele";
+	name = "SIT Teleporter Access";
+	pixel_x = 6;
+	pixel_y = 6;
+	req_access_txt = "153"
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "Ba" = (
-/obj/machinery/light/spot{
-	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (WEST)"
+/obj/structure/table/reinforced,
+/obj/machinery/door_control{
+	id = "sst_armory";
+	name = "SST Extra Weapons";
+	pixel_x = -6;
+	pixel_y = -4;
+	req_access_txt = "153"
 	},
-/obj/machinery/vending/tool,
+/obj/machinery/door_control{
+	id = "sst_ready";
+	name = "SST Base Access";
+	pixel_x = -6;
+	pixel_y = 6;
+	req_access_txt = "153"
+	},
+/obj/machinery/door_control{
+	id = "sst_tele";
+	name = "SST Teleporter Access";
+	pixel_x = 6;
+	pixel_y = 6;
+	req_access_txt = "153"
+	},
+/obj/machinery/door_control{
+	id = "sst_mechbay";
+	name = "SST Mech Bay";
+	pixel_x = 6;
+	pixel_y = -4;
+	req_access_txt = "153"
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -11669,15 +11721,25 @@
 /turf/simulated/shuttle/floor,
 /area/centcom/evac)
 "Bd" = (
-/obj/machinery/vending/coffee/free,
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
+	},
+/obj/machinery/pdapainter,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "Be" = (
 /obj/structure/table,
-/obj/item/storage/backpack/industrial,
-/obj/item/storage/backpack/industrial,
+/obj/machinery/light/spot{
+	dir = 4;
+	icon_state = "tube1";
+	tag = "icon-tube1 (EAST)"
+	},
+/obj/item/storage/backpack/satchel,
+/obj/item/storage/backpack/satchel,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -11688,17 +11750,15 @@
 /turf/simulated/shuttle/floor,
 /area/centcom/evac)
 "Bg" = (
-/obj/structure/table/wood,
-/obj/item/syndicatedetonator,
+/obj/machinery/computer/shuttle/sst,
 /turf/unsimulated/floor{
-	dir = 1;
-	icon_state = "carpetside"
+	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "Bh" = (
 /obj/structure/table,
-/obj/item/storage/backpack/medic,
-/obj/item/storage/backpack/medic,
+/obj/item/storage/backpack/industrial,
+/obj/item/storage/backpack/industrial,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -11727,33 +11787,36 @@
 /area/centcom/evac)
 "Bm" = (
 /obj/structure/table,
-/obj/item/storage/backpack/science,
-/obj/item/storage/backpack/science,
+/obj/item/storage/backpack/medic,
+/obj/item/storage/backpack/medic,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "Bn" = (
-/obj/machinery/door/airlock/hatch/syndicate,
+/obj/item/flag/syndi,
 /turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "bar"
+	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "Bo" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom/syndicate,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/syndicate{
+	pixel_x = 5
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = -9;
+	pixel_y = 10
+	},
 /turf/unsimulated/floor{
-	dir = 9;
-	icon_state = "carpetside"
+	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "Bp" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/drinkingglass/devilskiss,
+/obj/mecha/combat/marauder/mauler/loaded,
+/obj/effect/decal/warning_stripes/red/hollow,
 /turf/unsimulated/floor{
-	dir = 5;
-	icon_state = "carpetside"
+	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "Bq" = (
@@ -11764,9 +11827,12 @@
 /turf/simulated/floor/plating,
 /area/centcom/evac)
 "Br" = (
-/obj/structure/chair/office/dark,
+/obj/machinery/mech_bay_recharge_port/upgraded/unsimulated{
+	dir = 8;
+	icon_state = "recharge_port"
+	},
 /turf/unsimulated/floor{
-	icon_state = "dark"
+	name = "plating"
 	},
 /area/syndicate_mothership)
 "Bs" = (
@@ -11777,39 +11843,32 @@
 /turf/simulated/floor/plating,
 /area/centcom/evac)
 "Bt" = (
-/obj/structure/chair/comfy/red{
-	dir = 1;
-	icon_state = "comfychair"
-	},
-/obj/effect/landmark{
-	name = "Syndicate Officer"
-	},
+/obj/structure/table/wood,
+/obj/item/syndicatedetonator,
 /turf/unsimulated/floor{
-	dir = 2;
+	dir = 1;
 	icon_state = "carpetside"
 	},
 /area/syndicate_mothership)
 "Bu" = (
 /obj/structure/table/wood,
-/obj/machinery/door_control{
-	id = "commandcenter";
-	name = "Privacy Shutters";
-	req_access_txt = "153"
-	},
+/obj/item/radio/intercom/syndicate,
 /turf/unsimulated/floor{
-	dir = 10;
+	dir = 9;
 	icon_state = "carpetside"
 	},
 /area/syndicate_mothership)
 "Bv" = (
-/obj/machinery/computer/camera_advanced,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass/devilskiss,
 /turf/unsimulated/floor{
-	dir = 6;
+	dir = 5;
 	icon_state = "carpetside"
 	},
 /area/syndicate_mothership)
 "Bw" = (
 /obj/structure/table/reinforced,
+/obj/item/syndicatedetonator,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -11825,6 +11884,73 @@
 	},
 /area/syndicate_mothership)
 "By" = (
+/obj/structure/chair/office/dark,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"Bz" = (
+/obj/effect/landmark{
+	name = "Syndicate-Infiltrator";
+	tag = "Commando"
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"BA" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"BB" = (
+/obj/structure/table/wood,
+/obj/machinery/door_control{
+	id = "commandcenter";
+	name = "Privacy Shutters";
+	req_access_txt = "153"
+	},
+/turf/unsimulated/floor{
+	dir = 10;
+	icon_state = "carpetside"
+	},
+/area/syndicate_mothership)
+"BC" = (
+/obj/structure/chair/comfy/red{
+	dir = 1;
+	icon_state = "comfychair"
+	},
+/obj/effect/landmark{
+	name = "Syndicate Officer"
+	},
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "carpetside"
+	},
+/area/syndicate_mothership)
+"BD" = (
+/obj/machinery/computer/camera_advanced,
+/turf/unsimulated/floor{
+	dir = 6;
+	icon_state = "carpetside"
+	},
+/area/syndicate_mothership)
+"BE" = (
+/obj/effect/landmark{
+	name = "Syndicate-Infiltrator-Leader";
+	tag = "Commando"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"BF" = (
 /obj/machinery/computer/shuttle/syndicate{
 	name = "Nuclear Operatives Shuttle Console"
 	},
@@ -11832,7 +11958,7 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
-"Bz" = (
+"BG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
 	id = "nukeop_base";
@@ -11852,78 +11978,33 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
-"BA" = (
-/obj/structure/displaycase/stechkin,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"BB" = (
-/obj/structure/closet/secure_closet/syndicate_officer,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"BC" = (
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "sst_mechbay";
-	name = "Mech Bay"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"BD" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "Holding Cell"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"BE" = (
-/obj/structure/rack,
-/obj/item/storage/backpack/duffel/syndie/ammo/shotgun,
-/obj/item/storage/backpack/duffel/syndie/ammo/shotgun,
-/obj/item/gun/projectile/automatic/shotgun/bulldog,
-/obj/item/gun/projectile/automatic/shotgun/bulldog,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"BF" = (
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "sst_armory";
-	name = "Armory"
-	},
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"BG" = (
-/obj/mecha/combat/gygax/dark/loaded,
-/obj/effect/decal/warning_stripes/red/hollow,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
 "BH" = (
 /obj/structure/rack,
-/obj/item/ammo_box/magazine/smgm45,
-/obj/item/ammo_box/magazine/smgm45,
-/obj/item/ammo_box/magazine/smgm45,
-/obj/item/ammo_box/magazine/smgm45,
-/obj/item/ammo_box/magazine/smgm45,
-/obj/item/ammo_box/magazine/smgm45,
-/obj/item/ammo_box/magazine/smgm45,
-/obj/item/ammo_box/magazine/smgm45,
-/obj/item/gun/projectile/automatic/c20r,
-/obj/item/gun/projectile/automatic/c20r,
+/obj/item/storage/backpack/duffel/syndie/ammo/shotgun,
+/obj/item/storage/backpack/duffel/syndie/ammo/shotgun,
+/obj/item/gun/projectile/automatic/shotgun/bulldog,
+/obj/item/gun/projectile/automatic/shotgun/bulldog,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "BI" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/gun/projectile/automatic/c20r,
+/obj/item/gun/projectile/automatic/c20r,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"BJ" = (
 /obj/structure/rack,
 /obj/item/ammo_box/magazine/sniper_rounds,
 /obj/item/ammo_box/magazine/sniper_rounds,
@@ -11934,7 +12015,7 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
-"BJ" = (
+"BK" = (
 /obj/structure/rack,
 /obj/item/gun/medbeam,
 /obj/item/clothing/glasses/hud/health/night,
@@ -11942,56 +12023,46 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
-"BK" = (
-/obj/structure/rack,
-/obj/item/ammo_casing/rocket,
-/obj/item/ammo_casing/rocket,
-/obj/item/ammo_casing/rocket,
-/obj/item/ammo_casing/rocket,
-/obj/item/ammo_casing/rocket,
-/obj/item/gun/rocketlauncher,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
 "BL" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/closet/secure_closet/syndicate_officer,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "BM" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "SIT Ready Room"
-	},
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "sit_ready"
-	},
+/obj/structure/displaycase/stechkin,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "BN" = (
-/obj/machinery/door/airlock/hatch/syndicate{
-	name = "SST Ready Room"
+/obj/structure/mirror{
+	pixel_x = -28
 	},
-/obj/machinery/door/poddoor/impassable{
-	id_tag = "sst_ready"
+/obj/effect/landmark{
+	name = "Syndicate-Infiltrator";
+	tag = "Commando"
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "BO" = (
-/obj/machinery/bluespace_beacon/syndicate/infiltrator,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/mirror{
+	pixel_x = 28
+	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "BQ" = (
-/obj/machinery/mech_bay_recharge_port/upgraded/unsimulated,
-/turf/unsimulated/floor,
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "sst_mechbay";
+	name = "Mech Bay"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
 /area/syndicate_mothership)
 "BR" = (
 /obj/machinery/mech_bay_recharge_port/upgraded/unsimulated,
@@ -12000,14 +12071,31 @@
 	},
 /area/centcom/specops)
 "BS" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Holding Cell"
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "BT" = (
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "sst_armory";
+	name = "Armory"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"BU" = (
+/obj/structure/closet/secure_closet{
+	req_access_txt = "150"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"BV" = (
 /obj/machinery/door/window/northleft{
 	name = "cell door";
 	req_access_txt = "150"
@@ -12016,7 +12104,7 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
-"BU" = (
+"BW" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -12025,54 +12113,35 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
-"BV" = (
+"BX" = (
 /obj/structure/chair,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
-"BW" = (
+"BY" = (
 /obj/structure/chair/stool,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
-"BX" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/red,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
-"BY" = (
-/obj/structure/bed,
-/turf/unsimulated/floor{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
 "BZ" = (
-/obj/structure/closet/secure_closet{
-	req_access_txt = "150"
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "Ca" = (
-/obj/machinery/door/window/northleft{
-	name = "Out";
-	req_access_txt = "150"
-	},
+/obj/effect/decal/warning_stripes/blue,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "Cb" = (
-/obj/machinery/door/window/northright{
-	name = "In";
-	req_access_txt = "150"
-	},
+/obj/machinery/bluespace_beacon/syndicate/infiltrator,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
@@ -12086,25 +12155,167 @@
 	},
 /area/syndicate_mothership)
 "Cd" = (
-/obj/docking_port/stationary{
-	area_type = /area/syndicate_mothership;
-	dheight = 9;
-	dir = 2;
-	dwidth = 5;
-	height = 22;
-	id = "syndicate_away";
-	name = "syndicate base";
-	turf_type = /turf/unsimulated/floor/snow;
-	width = 18
+/obj/machinery/door/airlock/external{
+	id_tag = "syndicate_away";
+	req_access_txt = "150"
 	},
-/turf/unsimulated/floor/snow,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
 /area/syndicate_mothership)
+"Ci" = (
+/obj/item/stack/spacecash/c200,
+/obj/item/stack/spacecash/c50,
+/obj/machinery/light/spot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Cj" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell/high{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stock_parts/cell/high,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Ck" = (
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
+	},
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall_f5";
+	tag = "icon-swall_f5"
+	},
+/area/shuttle/transport)
+"Cl" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "burst_l"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/trade/sol)
+"Cm" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
+"Cn" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/drinkingglasses,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Cq" = (
+/obj/machinery/recharge_station/upgraded,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Cr" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "Cu" = (
 /obj/structure/bed/roller,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"Cv" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "SST Ready Room"
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "sst_ready"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"Cx" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "adminshuttle";
+	name = "Medbay";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Cz" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall3"
+	},
+/area/shuttle/trade/sol)
+"CA" = (
+/obj/machinery/light/spot{
+	dir = 4;
+	icon_state = "tube1";
+	tag = "icon-tube1 (EAST)"
+	},
+/obj/machinery/door_control{
+	id = "QMLoaddoor2";
+	layer = 3;
+	name = "Loading Doors";
+	pixel_x = 24;
+	pixel_y = 8;
+	req_access_txt = "0"
+	},
+/obj/machinery/door_control{
+	id = "QMLoaddoor";
+	layer = 3;
+	name = "Loading Doors";
+	pixel_x = 24;
+	pixel_y = -8;
+	req_access_txt = "0"
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/supply)
+"CD" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'FOURTH WALL'.";
+	name = "\improper FOURTH WALL";
+	pixel_x = -32
+	},
+/turf/unsimulated/floor/snow,
+/area/syndicate_mothership)
+"CE" = (
+/obj/structure/table,
+/obj/item/storage/backpack/science,
+/obj/item/storage/backpack/science,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"CF" = (
+/turf/unsimulated/floor/snow{
+	dir = 1;
+	icon_state = "gravsnow_corner";
+	tag = "icon-gravsnow_corner (NORTH)"
+	},
+/area/syndicate_mothership)
+"CG" = (
+/obj/effect/spawner/lootdrop/trade_sol/sec,
+/obj/structure/closet,
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
 "CJ" = (
 /obj/machinery/light/spot{
 	dir = 4;
@@ -12113,6 +12324,150 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
+"CK" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "adminshuttle";
+	name = "Bridge";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"CL" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/syndicate)
+"CM" = (
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/administration)
+"CN" = (
+/obj/machinery/computer/shuttle/trade/sol,
+/obj/machinery/door_control{
+	id = "soltrader_south";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = 8;
+	req_access_txt = "160"
+	},
+/obj/machinery/flasher_button{
+	id = "soltraderflash";
+	pixel_x = 24;
+	pixel_y = -8
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"CO" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"CP" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"CR" = (
+/turf/space,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
+"CU" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "syndieshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 2;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_end";
+	tag = "icon-window5_end"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate)
+"CZ" = (
+/obj/structure/rack,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/gun/rocketlauncher,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"Da" = (
+/obj/item/ashtray/glass,
+/obj/structure/table,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Dd" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "adminshuttle";
+	name = "Holding Cell";
+	opacity = 1;
+	req_access_txt = "104"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"De" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "SIT Ready Room"
+	},
+/obj/machinery/door/poddoor/impassable{
+	id_tag = "sit_ready"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"Df" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall_f9";
+	tag = "icon-swall_f9"
+	},
+/area/shuttle/supply)
+"Dg" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	autoclose = 0;
+	frequency = 1441;
+	id_tag = "syndicate_jail_airlock_external";
+	locked = 1;
+	name = "Syndicate Jail External Airlock"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
 "Di" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -12120,6 +12475,38 @@
 /obj/structure/shuttle/engine/heater,
 /turf/simulated/shuttle/plating,
 /area/shuttle/escape)
+"Dm" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swallc3"
+	},
+/area/shuttle/trade/sol)
+"Do" = (
+/turf/unsimulated/wall/fakeglass{
+	dir = 1;
+	icon_state = "fakewindows"
+	},
+/area/syndicate_mothership)
+"Dq" = (
+/obj/structure/table,
+/obj/item/kitchen/knife/butcher,
+/obj/item/melee/baseball_bat,
+/obj/item/clothing/mask/muzzle{
+	pixel_y = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"Dr" = (
+/obj/machinery/light/spot{
+	dir = 4;
+	icon_state = "tube1";
+	tag = "icon-tube1 (EAST)"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "Dv" = (
 /turf/space,
 /area/admin)
@@ -12136,6 +12523,57 @@
 "DC" = (
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
+"DF" = (
+/obj/machinery/vending/tool,
+/turf/unsimulated/floor{
+	icon_state = "dark";
+	tag = "icon-dark"
+	},
+/area/syndicate_mothership)
+"DG" = (
+/obj/machinery/door/window/westleft,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"DH" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall_f5";
+	tag = "icon-swall_f5"
+	},
+/area/shuttle/trade/sol)
+"DN" = (
+/obj/structure/closet/crate/internals,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/mask/gas,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/mask/gas,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"DR" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall_f9"
+	},
+/area/shuttle/trade/sol)
+"DV" = (
+/obj/machinery/door/window/brigdoor/westleft{
+	color = "#d70000";
+	req_access_txt = "104"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
 "DX" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/admin)
@@ -12150,11 +12588,112 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"DZ" = (
+/obj/machinery/cell_charger,
+/obj/structure/table,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Ea" = (
+/obj/item/clothing/head/collectable/petehat{
+	desc = "It smells faintly of reptile.";
+	name = "fancy leader hat"
+	},
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Eb" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/specops)
+"Ec" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"Eg" = (
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/glass/bottle/morphine,
+/obj/item/storage/box/beakers,
+/obj/item/robot_parts/l_arm,
+/obj/item/robot_parts/r_arm,
+/obj/item/clothing/mask/surgical,
+/obj/item/reagent_containers/iv_bag/blood/OMinus,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/robot_parts/l_leg,
+/obj/item/robot_parts/r_leg,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Ej" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1441;
+	master_tag = "syndicate_jail_airlock_control";
+	name = "Syndicate Jail Access Button";
+	pixel_y = 24;
+	req_access_txt = "150"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"Em" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/admin{
+	name = "NTV Argos shuttle navigation computer"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"En" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
 "Eo" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swallc4"
 	},
 /area/shuttle/escape)
+"Er" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "open";
+	id_tag = "voxshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 8;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_end";
+	tag = "icon-window5_end (WEST)"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"Eu" = (
+/obj/machinery/flasher{
+	id = "soltraderflash";
+	pixel_y = -28
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
 "Ew" = (
 /turf/simulated/shuttle/wall{
 	dir = 2;
@@ -12162,6 +12701,103 @@
 	tag = "icon-swall13"
 	},
 /area/shuttle/escape)
+"EE" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/vox)
+"EF" = (
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 2;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_end";
+	tag = "icon-window5_end"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"EG" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "burst_r";
+	tag = "icon-burst_r"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/supply)
+"EH" = (
+/obj/item/soap/syndie,
+/obj/structure/mopbucket,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "freezerfloor"
+	},
+/area/syndicate_mothership)
+"EL" = (
+/obj/machinery/light,
+/turf/simulated/floor/plating,
+/area/syndicate_mothership)
+"EQ" = (
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"ER" = (
+/obj/machinery/light/spot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/transport)
+"ES" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	frequency = 1331;
+	id_tag = "synd_pump"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"EU" = (
+/obj/structure/table,
+/obj/item/circular_saw,
+/obj/item/surgicaldrill{
+	pixel_y = 5
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"Fe" = (
+/turf/space,
+/turf/space,
+/turf/unsimulated/wall/fakeglass{
+	dir = 8;
+	icon_state = "fakewindows"
+	},
+/area/syndicate_mothership)
+"Fi" = (
+/obj/machinery/light/spot{
+	dir = 4;
+	icon_state = "tube1";
+	tag = "icon-tube1 (EAST)"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
+"Fk" = (
+/obj/structure/closet/syndicate/nuclear,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "Fm" = (
 /obj/machinery/optable,
 /turf/simulated/shuttle/floor{
@@ -12176,9 +12812,76 @@
 	icon_state = "floor2"
 	},
 /area/shuttle/escape)
+"Fu" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "burst_l";
+	tag = "icon-burst_l"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/supply)
+"Fw" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light/spot,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Fx" = (
+/obj/structure/bed,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"Fz" = (
+/turf/unsimulated/wall,
+/area/syndicate_mothership/jail)
+"FC" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark";
+	tag = "icon-dark"
+	},
+/area/syndicate_mothership)
+"FE" = (
+/obj/structure/table,
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"FI" = (
+/obj/structure/kitchenspike,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
 "FL" = (
 /turf/simulated/wall/r_wall,
 /area/adminconstruction)
+"FM" = (
+/obj/machinery/kitchen_machine/microwave/upgraded,
+/obj/structure/table,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"FP" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "burst_l"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/specops)
 "FQ" = (
 /turf/simulated/shuttle/wall{
 	dir = 2;
@@ -12186,6 +12889,15 @@
 	tag = "icon-swall_f5"
 	},
 /area/shuttle/escape)
+"FS" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
 "FW" = (
 /obj/machinery/light/spot{
 	dir = 1;
@@ -12196,17 +12908,176 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"FZ" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1331;
+	master_tag = "vox_west_control";
+	req_one_access_txt = "152"
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/shuttle/vox)
 "Ga" = (
 /obj/machinery/computer/shuttle/ert,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"Gc" = (
+/obj/machinery/door_control{
+	id = "adminshuttleblast";
+	name = "blast door control";
+	pixel_x = -30;
+	req_access_txt = "101"
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Gd" = (
+/obj/structure/plasticflaps/mining,
+/obj/machinery/conveyor/east{
+	id = "QMLoad2"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/supply)
+"Gi" = (
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Gj" = (
+/obj/machinery/chem_master,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
+"Gl" = (
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1441;
+	master_tag = "syndicate_jail_airlock_control";
+	name = "Syndicate Jail Access Button";
+	pixel_x = -24;
+	pixel_y = -8;
+	req_access_txt = "150"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"Go" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 32
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/specops)
+"Gp" = (
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/transport)
+"Gr" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/shuttle/syndicate)
+"Gs" = (
+/obj/structure/rack,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/suit/space/vox/carapace,
+/obj/item/clothing/head/helmet/space/vox/carapace,
+/obj/item/clothing/mask/breath,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Gy" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 2;
+	frequency = 1331;
+	id_tag = "synd_pump"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"GD" = (
+/obj/structure/closet/syndicate/personal,
+/turf/unsimulated/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/syndicate_mothership)
+"GG" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
+"GJ" = (
+/obj/structure/shuttle/window,
+/obj/structure/grille,
+/turf/simulated/shuttle/plating,
+/area/shuttle/trade/sol)
+"GM" = (
+/obj/machinery/dna_scannernew/upgraded,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
 "GP" = (
 /turf/unsimulated/floor{
 	icon_state = "gcircuit"
 	},
 /area/admin)
+"GQ" = (
+/turf/unsimulated/wall/fakeglass{
+	dir = 8;
+	icon_state = "fakewindows3";
+	tag = "icon-fakewindows (WEST)"
+	},
+/area/syndicate_mothership/jail)
+"GV" = (
+/obj/structure/bed,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"GW" = (
+/obj/machinery/bodyscanner,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
 "GX" = (
 /obj/machinery/computer/crew,
 /turf/simulated/shuttle/floor,
@@ -12219,6 +13090,12 @@
 	icon_state = "engine"
 	},
 /area/admin)
+"Hc" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "152"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
 "Hg" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/space/space_ninja,
@@ -12241,6 +13118,29 @@
 "Hj" = (
 /turf/unsimulated/wall,
 /area/tdome)
+"Hm" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/assault_pod)
+"Ho" = (
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"Hq" = (
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/specops)
 "Hu" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/space_ninja,
@@ -12274,6 +13174,20 @@
 	icon_state = "white"
 	},
 /area/tdome)
+"HB" = (
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 1;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_end";
+	tag = "icon-window5_end (NORTH)"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"HC" = (
+/obj/effect/decal/warning_stripes/northeast,
+/turf/simulated/floor/plating/airless,
+/area/syndicate_mothership)
 "HD" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle{
@@ -12281,6 +13195,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
+"HF" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/shuttle/floor,
+/area/shuttle/transport)
+"HG" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"HH" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"HL" = (
+/obj/effect/decal/warning_stripes/southwest,
+/turf/space,
+/turf/space,
+/turf/simulated/floor/plating/airless,
+/area/syndicate_mothership)
 "HN" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -12294,6 +13232,12 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"HO" = (
+/obj/machinery/optable,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
 "HR" = (
 /obj/structure/closet/secure_closet/freezer/meat{
 	req_access_txt = "112"
@@ -12336,6 +13280,28 @@
 	icon_state = "white"
 	},
 /area/tdome)
+"Ib" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/crowbar/red,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Id" = (
+/obj/machinery/iv_drip,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
+"Ie" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/circular_saw,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
 "If" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "swallc3"
@@ -12363,6 +13329,71 @@
 	name = "plating"
 	},
 /area/tdome/tdome2)
+"Im" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "syndieshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 2;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_mid";
+	tag = "icon-window5_mid"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate)
+"In" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1331;
+	icon_state = "door_locked";
+	id_tag = "synd_outer";
+	locked = 0;
+	name = "Ship External Access";
+	req_access = null;
+	req_access_txt = "150"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "smindicate";
+	name = "Outer Airlock";
+	opacity = 0
+	},
+/obj/machinery/door_control{
+	id = "smindicate";
+	name = "External Door Control";
+	pixel_x = -26;
+	pixel_y = -2;
+	req_access_txt = "150"
+	},
+/obj/docking_port/mobile{
+	dheight = 9;
+	dir = 2;
+	dwidth = 5;
+	height = 22;
+	id = "syndicate";
+	name = "syndicate infiltrator";
+	roundstart_move = null;
+	width = 18
+	},
+/obj/docking_port/stationary{
+	area_type = /area/syndicate_mothership;
+	dheight = 9;
+	dir = 2;
+	dwidth = 5;
+	height = 22;
+	id = "syndicate_away";
+	name = "syndicate base";
+	turf_type = /turf/unsimulated/floor/snow;
+	width = 18
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate)
 "Io" = (
 /turf/unsimulated/floor{
 	name = "plating"
@@ -12395,9 +13426,37 @@
 	name = "plating"
 	},
 /area/tdome/tdome1)
+"Iv" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall3";
+	tag = "icon-swall3"
+	},
+/area/shuttle/transport)
 "Iw" = (
 /turf/simulated/floor/bluegrid,
 /area/tdome/arena)
+"Iz" = (
+/obj/machinery/bodyscanner,
+/obj/machinery/light/spot,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"IA" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "soltradeship_north";
+	name = "Security Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/shuttle/glass{
+	id_tag = "soltrader_north";
+	name = "trader shuttle airlock";
+	req_access_txt = "160";
+	security_level = 6
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
 "IB" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -12406,11 +13465,122 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"ID" = (
+/obj/machinery/vending/snack,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"IE" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"IG" = (
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
+"IJ" = (
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plating/airless,
+/area/syndicate_mothership)
+"IM" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/assault_pod)
+"IO" = (
+/obj/item/flag/syndi,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
+"IR" = (
+/obj/machinery/autolathe/upgraded{
+	hacked = 1
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
 "IS" = (
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/tdome/tdomeadmin)
+"IW" = (
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "wall3"
+	},
+/area/shuttle/administration)
+"IY" = (
+/obj/machinery/vending/cola,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"IZ" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/donkpockets,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"Ja" = (
+/obj/structure/flora/grass/brown,
+/turf/space,
+/turf/unsimulated/floor/snow,
+/area/syndicate_mothership)
+"Jc" = (
+/obj/machinery/light/spot,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"Jg" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "open";
+	id_tag = "voxshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 4;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_mid";
+	tag = "icon-window5 (EAST)"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"Jh" = (
+/obj/machinery/door_control{
+	id = "adminshuttleblast";
+	name = "blast door control";
+	pixel_x = -30;
+	req_access_txt = "101"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Ji" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall12"
+	},
+/area/shuttle/trade/sol)
 "Jk" = (
 /turf/simulated/shuttle/wall{
 	dir = 2;
@@ -12418,12 +13588,78 @@
 	tag = "icon-swall11"
 	},
 /area/shuttle/escape)
+"Jl" = (
+/obj/effect/decal/remains/human,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"Jn" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall_f6";
+	tag = "icon-swall_f6"
+	},
+/area/shuttle/supply)
+"Jo" = (
+/obj/structure/flora/bush,
+/turf/unsimulated/floor/snow,
+/area/syndicate_mothership)
+"Jp" = (
+/obj/machinery/airlock_sensor{
+	frequency = 1331;
+	id_tag = "vox_east_sensor";
+	pixel_x = -25;
+	req_access_txt = "152"
+	},
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
 "Jq" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
 /area/shuttle/escape)
+"Jr" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/assault_pod)
+"Jv" = (
+/obj/machinery/light/spot,
+/obj/effect/spawner/lootdrop/trade_sol/serv,
+/obj/structure/closet,
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"Jy" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/multitool,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"JB" = (
+/obj/structure/sign/double/map/right{
+	pixel_y = -32
+	},
+/obj/structure/rack/skeletal_bar/right,
+/obj/item/reagent_containers/food/drinks/bottle/gin,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "wood"
+	},
+/area/syndicate_mothership)
 "JC" = (
 /obj/structure/chair/stool,
 /obj/item/clothing/head/bandana{
@@ -12436,6 +13672,33 @@
 /obj/structure/chair/stool,
 /turf/unsimulated/beach/sand,
 /area/ninja/holding)
+"JF" = (
+/obj/structure/rack,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/suit/space/vox/pressure,
+/obj/item/clothing/head/helmet/space/vox/pressure,
+/obj/item/clothing/mask/breath,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"JG" = (
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"JI" = (
+/obj/machinery/teleport/hub/upgraded,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"JM" = (
+/turf/simulated/floor/plating,
+/area/syndicate_mothership)
 "JQ" = (
 /obj/machinery/light/spot{
 	dir = 1;
@@ -12447,6 +13710,43 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"JR" = (
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/vox)
+"JS" = (
+/obj/structure/shuttle/window,
+/obj/structure/grille,
+/turf/simulated/shuttle/plating,
+/area/shuttle/transport)
+"JU" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/space/syndicate/black/red,
+/obj/item/clothing/head/helmet/space/syndicate/black/red,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	frequency = 1331;
+	id_tag = "synd_pump"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"JY" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1331;
+	id_tag = "vox_west_control";
+	pixel_x = 24;
+	req_access_txt = "152";
+	tag_airpump = "vox_west_vent";
+	tag_chamber_sensor = "vox_west_sensor";
+	tag_exterior_door = "vox_northwest_lock";
+	tag_interior_door = "vox_southwest_lock"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
 "JZ" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -12455,6 +13755,10 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"Ka" = (
+/obj/item/broken_bottle,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
 "Kc" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -12495,6 +13799,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/dynamic/source/lobby_russian)
+"Kj" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/crowbar/red,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "Kk" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/wood,
@@ -12506,6 +13818,18 @@
 /obj/machinery/light/spot,
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
+"Km" = (
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Kn" = (
+/obj/machinery/vending/syndicigs,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
 "Kq" = (
 /obj/structure/chair/comfy/red,
 /obj/effect/landmark{
@@ -12513,6 +13837,22 @@
 	},
 /turf/unsimulated/floor/vox,
 /area/vox_station)
+"Ks" = (
+/obj/structure/rack,
+/obj/item/rcd,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Ku" = (
+/obj/structure/table,
+/obj/item/gun/energy/ionrifle,
+/turf/unsimulated/floor{
+	icon_state = "dark";
+	tag = "icon-dark"
+	},
+/area/syndicate_mothership)
 "Kv" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark{
@@ -12520,27 +13860,103 @@
 	},
 /turf/unsimulated/floor/vox,
 /area/vox_station)
+"Kw" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate)
+"Kx" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate)
+"Ky" = (
+/obj/machinery/mech_bay_recharge_port/upgraded/unsimulated,
+/turf/unsimulated/floor,
+/area/syndicate_mothership)
+"Kz" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall_f10";
+	tag = "icon-swall_f10"
+	},
+/area/shuttle/supply)
 "KA" = (
 /obj/structure/chair/sofa/left,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
 /area/shuttle/escape)
+"KC" = (
+/obj/structure/table/glass,
+/obj/item/storage/backpack/duffel/syndie/surgery_fake,
+/obj/item/circular_saw,
+/obj/item/surgicaldrill,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"KG" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/shuttle/specops)
+"KH" = (
+/obj/structure/flora/tree/pine{
+	pixel_x = 1
+	},
+/turf/unsimulated/floor/snow{
+	dir = 10;
+	icon_state = "gravsnow_corner";
+	tag = "icon-gravsnow_corner (SOUTHWEST)"
+	},
+/area/syndicate_mothership)
 "KK" = (
 /obj/machinery/tcomms/relay/cc,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/centcom/control)
-"KR" = (
-/obj/machinery/light/small,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
+"KL" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1331;
+	master_tag = "vox_west_control";
+	req_one_access_txt = "152"
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/shuttle/vox)
+"KP" = (
+/obj/structure/chair/office/dark,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"KQ" = (
+/obj/machinery/computer/security{
+	network = list("SS13","Research Outpost","Mining Outpost")
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
-/area/shuttle/assault_pod)
+/area/shuttle/specops)
+"KR" = (
+/obj/mecha/combat/gygax/dark/loaded,
+/obj/effect/decal/warning_stripes/red/hollow,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"KS" = (
+/obj/machinery/vending/medical,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
 "KU" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/structure/closet/walllocker/emerglocker{
@@ -12550,45 +13966,255 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/escape)
-"KW" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/chair/comfy/shuttle,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
-	},
-/area/shuttle/assault_pod)
-"KX" = (
+"KV" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
+/area/shuttle/syndicate)
+"KW" = (
+/obj/machinery/computer/shuttle/syndicate/drop_pod,
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
 /area/shuttle/assault_pod)
 "KY" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/shuttle/assault_pod)
+"KZ" = (
+/obj/machinery/light/spot{
+	dir = 4;
+	icon_state = "tube1";
+	tag = "icon-tube1 (EAST)"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
-/area/shuttle/assault_pod)
+/area/shuttle/administration)
+"Lc" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/item/clothing/mask/breath,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Lf" = (
+/obj/machinery/porta_turret/syndicate,
+/turf/simulated/shuttle/wall{
+	dir = 8;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/syndicate)
+"Lj" = (
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/specops)
+"Lp" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	damage_deflection = 75;
+	id_tag = "syndicate_jail_cell";
+	locked = 1;
+	name = "Syndicate Jail Cell"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"Lq" = (
+/turf/unsimulated/wall/fakeglass{
+	dir = 4;
+	icon_state = "fakewindows";
+	tag = "icon-fakewindows (EAST)"
+	},
+/area/syndicate_mothership)
+"Lr" = (
+/obj/machinery/atmospherics/unary/tank/air{
+	dir = 2
+	},
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "wall3"
+	},
+/area/shuttle/syndicate)
+"Ls" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 0
+	},
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Lt" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	autoclose = 0;
+	frequency = 1441;
+	id_tag = "syndicate_jail_airlock_internal";
+	locked = 1;
+	name = "Syndicate Jail Internal Airlock"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"Lx" = (
+/obj/effect/spawner/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"Lz" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/beer,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
 "LA" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
+"LC" = (
+/obj/structure/table,
+/obj/item/storage/lockbox/mindshield,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"LD" = (
+/obj/structure/rack,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/suit/space/vox/stealth,
+/obj/item/clothing/head/helmet/space/vox/stealth,
+/obj/item/clothing/mask/breath,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"LE" = (
+/obj/structure/table,
+/obj/item/storage/box/chemimp{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/storage/box/trackimp,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"LF" = (
+/obj/machinery/atm{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"LH" = (
+/obj/machinery/suit_storage_unit/syndicate/secure,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"LI" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_l";
+	tag = "icon-propulsion_l (EAST)"
+	},
+/turf/space,
+/area/shuttle/administration)
 "LJ" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/shuttle/plating,
 /area/shuttle/escape)
+"LK" = (
+/obj/machinery/light/spot,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"LL" = (
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
+	},
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall_f6";
+	tag = "icon-swall_f6"
+	},
+/area/shuttle/transport)
+"LM" = (
+/obj/structure/rack,
+/obj/item/gun/dartgun/vox/raider,
+/obj/item/gun/dartgun/vox/medical,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
+/obj/item/dart_cartridge,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"LN" = (
+/obj/machinery/camera{
+	c_tag = "CentComm Special Ops. Shuttle";
+	dir = 2;
+	network = list("ERT","CentComm")
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/specops)
 "LO" = (
 /obj/machinery/computer/communications,
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
+"LR" = (
+/obj/structure/table,
+/obj/item/reagent_containers/syringe/charcoal,
+/obj/item/reagent_containers/syringe/charcoal{
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/syringe/charcoal{
+	pixel_y = 4
+	},
+/obj/item/gun/syringe/syndicate,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/box/syndie_kit/bonerepair,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"LT" = (
+/obj/structure/closet/syndicate/personal,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"LU" = (
+/obj/machinery/recharge_station/upgraded,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
 "LV" = (
 /obj/machinery/computer/emergency_shuttle,
 /turf/simulated/shuttle/floor,
@@ -12602,6 +14228,11 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/escape)
+"LY" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/shuttle/vox)
 "LZ" = (
 /obj/mecha/combat/marauder/seraph/loaded,
 /obj/effect/decal/warning_stripes/yellow,
@@ -12609,6 +14240,114 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"Md" = (
+/obj/structure/chair/stool,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Mf" = (
+/obj/effect/spawner/lootdrop/trade_sol/med,
+/obj/structure/closet,
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"Mh" = (
+/obj/machinery/door/window{
+	dir = 4;
+	name = "Infirmary";
+	req_access_txt = "150"
+	},
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Mi" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/administration)
+"Mj" = (
+/obj/machinery/iv_drip,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Mk" = (
+/obj/machinery/optable,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Mp" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "burst_r"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/trade/sol)
+"Mq" = (
+/obj/machinery/computer/scan_consolenew,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
+"Mr" = (
+/obj/structure/rack,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/suit/space/vox/medic,
+/obj/item/clothing/head/helmet/space/vox/medic,
+/obj/item/clothing/mask/breath,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Ms" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "open";
+	id_tag = "adminshuttleshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 8;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_end";
+	tag = "icon-window5_end (WEST)"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/administration)
+"Mu" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "syndieshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 1;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_end";
+	tag = "icon-window5_end (NORTH)"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate)
+"Mz" = (
+/obj/effect/spawner/lootdrop/trade_sol/largeitem,
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"MC" = (
+/obj/machinery/computer/shuttle/vox,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
 "ME" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -12636,6 +14375,23 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"MH" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Hatch";
+	req_access_txt = "101"
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"MI" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
 "MK" = (
 /obj/machinery/light/spot{
 	dir = 8;
@@ -12649,6 +14405,15 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/escape)
+"MM" = (
+/obj/structure/urinal{
+	pixel_y = 28
+	},
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "freezerfloor"
+	},
+/area/syndicate_mothership)
 "MS" = (
 /obj/machinery/computer/robotics,
 /turf/simulated/shuttle/floor,
@@ -12659,6 +14424,95 @@
 	icon_state = "swall3"
 	},
 /area/shuttle/escape)
+"MY" = (
+/obj/structure/rack,
+/obj/item/pneumatic_cannon,
+/obj/item/harpoon,
+/obj/item/harpoon,
+/obj/item/harpoon,
+/obj/item/harpoon,
+/obj/item/tank/internals/nitrogen,
+/obj/machinery/light/spot{
+	dir = 4;
+	icon_state = "tube1";
+	tag = "icon-tube1 (EAST)"
+	},
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"MZ" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall_f6";
+	tag = "icon-swall_f6"
+	},
+/area/shuttle/trade/sol)
+"Na" = (
+/obj/machinery/clonepod/upgraded,
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
+"Nb" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Nc" = (
+/obj/machinery/light,
+/turf/simulated/floor/plating/airless,
+/area/syndicate_mothership)
+"Ne" = (
+/obj/item/stack/spacecash/c50,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Nh" = (
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"Nj" = (
+/obj/machinery/porta_turret/syndicate/pod,
+/turf/simulated/shuttle/wall{
+	dir = 1;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/assault_pod)
+"Nn" = (
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
+	},
+/obj/machinery/sleeper/syndie{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"No" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1331;
+	master_tag = "synd_airlock";
+	name = "interior access button";
+	pixel_x = 25;
+	pixel_y = 25;
+	req_access_txt = "0"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "Np" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12667,6 +14521,23 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"Nq" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall3";
+	tag = "icon-swall3"
+	},
+/area/shuttle/supply)
+"Nr" = (
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/obj/effect/spawner/lootdrop/trade_sol/donksoft,
+/obj/structure/closet,
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
 "Nt" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Escape Shuttle Cockpit";
@@ -12680,12 +14551,29 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
+"Nx" = (
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "wall3"
+	},
+/area/shuttle/vox)
 "Nz" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/unsimulated/floor{
 	name = "plating"
 	},
 /area/centcom/control)
+"NE" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1331;
+	master_tag = "vox_east_control";
+	req_access_txt = "152"
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/shuttle/vox)
 "NF" = (
 /obj/machinery/bsa/full/admin/east,
 /obj/effect/decal/warning_stripes/north,
@@ -12705,12 +14593,33 @@
 	name = "plating"
 	},
 /area/centcom/control)
+"NK" = (
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"NN" = (
+/turf/unsimulated/wall/fakeglass,
+/area/syndicate_mothership/jail)
 "NR" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
 /area/shuttle/escape)
+"NS" = (
+/obj/item/storage/fancy/crayons,
+/obj/machinery/light{
+	dir = 1;
+	on = 1
+	},
+/obj/structure/table,
+/obj/item/storage/fancy/crayons,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "freezerfloor"
+	},
+/area/syndicate_mothership)
 "NT" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -12721,6 +14630,17 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"NZ" = (
+/turf/simulated/shuttle/floor,
+/area/shuttle/transport)
+"Oa" = (
+/obj/machinery/door/airlock/hatch/syndicate{
+	name = "Torture Room"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
 "Ob" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -12729,12 +14649,30 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/escape)
+"Oc" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall13"
+	},
+/area/shuttle/trade/sol)
 "Oh" = (
 /obj/effect/decal/warning_stripes/southwest,
 /turf/unsimulated/floor{
 	name = "plating"
 	},
 /area/centcom/control)
+"Oj" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall8";
+	tag = "icon-swall12"
+	},
+/area/shuttle/trade/sol)
+"Ok" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/light,
+/turf/simulated/floor/plating/airless,
+/area/syndicate_mothership)
 "Oq" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/unsimulated/floor{
@@ -12747,6 +14685,82 @@
 	name = "plating"
 	},
 /area/centcom/control)
+"Ou" = (
+/obj/structure/rack,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Ow" = (
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/specops)
+"Ox" = (
+/obj/machinery/porta_turret/syndicate,
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "wall3"
+	},
+/area/shuttle/syndicate)
+"OC" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "s_docking_airlock";
+	name = "Shuttle Hatch";
+	req_access_txt = "109"
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/specops)
+"OE" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "burst_r"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/specops)
+"OF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/soda,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"OH" = (
+/obj/machinery/door/airlock/centcom{
+	aiControlDisabled = 1;
+	name = "Assault Pod";
+	opacity = 1;
+	req_one_access_txt = "150"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/assault_pod)
+"OJ" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "heater";
+	tag = "icon-heater (WEST)"
+	},
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 4
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/shuttle/administration)
+"OK" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Restroom";
+	opacity = 1;
+	req_access_txt = "150"
+	},
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
 "OL" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -12756,6 +14770,16 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
+"OM" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "syndicate_away";
+	req_access_txt = "150"
+	},
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
 "OP" = (
 /obj/effect/decal/warning_stripes/yellow/partial{
 	dir = 8
@@ -12767,6 +14791,56 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"OQ" = (
+/obj/machinery/sleeper/upgraded{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"OT" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"OV" = (
+/turf/simulated/shuttle/wall{
+	dir = 1;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/administration)
+"OZ" = (
+/obj/machinery/light/spot{
+	dir = 4;
+	icon_state = "tube1";
+	tag = "icon-tube1 (EAST)"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"Pa" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "voxshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 2;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_mid";
+	tag = "icon-window5_mid"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"Pd" = (
+/obj/structure/closet/secure_closet/contractor,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
 "Pn" = (
 /obj/mecha/combat/marauder/loaded,
 /obj/effect/decal/warning_stripes/yellow,
@@ -12779,6 +14853,76 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"Pr" = (
+/obj/structure/table,
+/obj/machinery/door_control{
+	id = "voxshutters";
+	name = "remote shutter control";
+	req_access_txt = "152"
+	},
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Pu" = (
+/obj/structure/dispenser,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Pw" = (
+/obj/machinery/door/airlock/hatch{
+	frequency = 1331;
+	icon_state = "door_locked";
+	id_tag = "vox_southwest_lock";
+	locked = 1;
+	req_access_txt = "152";
+	req_one_access = null;
+	req_one_access_txt = "0"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"Py" = (
+/obj/item/storage/box/zipties,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"PA" = (
+/obj/structure/table,
+/obj/machinery/kitchen_machine/microwave,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"PC" = (
+/obj/structure/table,
+/obj/item/radio/electropack{
+	pixel_x = -5
+	},
+/obj/item/assembly/signaler{
+	code = 2;
+	frequency = 1449;
+	pixel_x = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"PD" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Tactical Toilet";
+	opacity = 1;
+	req_access_txt = "150"
+	},
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "freezerfloor"
+	},
+/area/syndicate_mothership)
 "PF" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = null;
@@ -12787,12 +14931,78 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
+"PG" = (
+/turf/unsimulated/wall/fakeglass{
+	dir = 6;
+	icon_state = "fakewindows";
+	tag = "icon-fakewindows (SOUTHEAST)"
+	},
+/area/syndicate_mothership/jail)
+"PH" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion_l";
+	tag = "icon-propulsion_l"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/vox)
 "PJ" = (
 /obj/effect/decal/warning_stripes/west,
 /turf/unsimulated/floor{
 	name = "plating"
 	},
 /area/centcom/specops)
+"PK" = (
+/obj/structure/table/wood,
+/obj/machinery/door_control{
+	id = "syndicate_jail_cell";
+	name = "Bolt Cell Doors";
+	normaldoorcontrol = 1;
+	pixel_x = 6;
+	pixel_y = 0;
+	req_access_txt = "150";
+	specialfunctions = 4
+	},
+/obj/machinery/door_control{
+	id = "syndicate_jail";
+	name = "Bolt Jail Door";
+	normaldoorcontrol = 1;
+	pixel_x = -5;
+	pixel_y = 0;
+	req_access_txt = "150";
+	specialfunctions = 4
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"PM" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "open";
+	id_tag = "voxshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 4;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_end";
+	tag = "icon-window5_end (EAST)"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"PN" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table,
+/mob/living/simple_animal/bot/floorbot{
+	on = 0
+	},
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
 "PQ" = (
 /obj/machinery/door/airlock/shuttle{
 	aiControlDisabled = 1;
@@ -12811,6 +15021,19 @@
 	tag = "icon-swall7"
 	},
 /area/shuttle/escape)
+"PX" = (
+/obj/structure/table,
+/obj/item/storage/box/zipties,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"PY" = (
+/obj/structure/chair/stool/bar,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
 "Qa" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -12826,6 +15049,41 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"Qb" = (
+/obj/machinery/light/small{
+	dir = 8;
+	icon_state = "bulb1";
+	tag = "icon-bulb1 (WEST)"
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/assault_pod)
+"Qe" = (
+/turf/unsimulated/floor/snow{
+	dir = 1;
+	icon_state = "gravsnow_corner";
+	tag = "icon-gravsnow_corner (NORTH)"
+	},
+/turf/unsimulated/floor/snow,
+/area/syndicate_mothership)
+"Qi" = (
+/obj/machinery/vending/wallmed/syndicate{
+	pixel_x = -30
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Qj" = (
+/obj/item/clothing/head/collectable/xenom,
+/obj/item/clothing/head/chicken,
+/obj/item/aiModule/syndicate,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
 "Ql" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -12839,10 +15097,67 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"Qm" = (
+/mob/living/simple_animal/pet/dog/fox/Syndifox,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
+"Qr" = (
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Qs" = (
+/obj/structure/table,
+/obj/item/grenade/plastic/c4{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "Qt" = (
 /obj/machinery/poolcontroller/invisible,
 /turf/unsimulated/beach/water,
 /area/ninja/holding)
+"Qu" = (
+/obj/machinery/computer/communications,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Qw" = (
+/obj/structure/table,
+/obj/item/aicard,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Qx" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/toy/cards/deck/syndicate{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
+"QC" = (
+/obj/machinery/porta_turret/syndicate,
+/turf/simulated/shuttle/wall{
+	dir = 1;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/syndicate)
 "QD" = (
 /obj/machinery/computer/crew,
 /obj/machinery/status_display{
@@ -12861,6 +15176,12 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/escape)
+"QG" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "QH" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -12885,6 +15206,36 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/escape)
+"QJ" = (
+/obj/machinery/computer/cloning,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
+"QL" = (
+/obj/machinery/light/spot,
+/obj/structure/table/reinforced,
+/obj/item/radio/beacon/syndicate/bomb{
+	pixel_y = 8
+	},
+/obj/item/radio/beacon/syndicate/bomb{
+	pixel_y = 4
+	},
+/obj/item/radio/beacon/syndicate/bomb,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"QM" = (
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Tool Storage";
+	req_access_txt = "150"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "QP" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -12893,6 +15244,51 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"QR" = (
+/obj/structure/rack,
+/obj/item/tank/internals/nitrogen,
+/obj/item/tank/internals/nitrogen,
+/obj/item/tank/internals/nitrogen,
+/obj/item/tank/internals/nitrogen,
+/obj/item/tank/internals/nitrogen,
+/obj/item/tank/internals/nitrogen,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"QS" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1331;
+	id_tag = "vox_east_control";
+	pixel_x = -24;
+	req_access_txt = "152";
+	tag_airpump = "vox_east_vent";
+	tag_chamber_sensor = "vox_east_sensor";
+	tag_exterior_door = "vox_northeast_lock";
+	tag_interior_door = "vox_southeast_lock"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"QV" = (
+/obj/machinery/light/spot{
+	dir = 4;
+	icon_state = "tube1";
+	tag = "icon-tube1 (EAST)"
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Ra" = (
+/obj/item/radio/intercom/syndicate{
+	pixel_x = -28
+	},
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "wood"
+	},
+/area/syndicate_mothership)
 "Rf" = (
 /obj/structure/chair{
 	dir = 1
@@ -12901,6 +15297,34 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"Rg" = (
+/turf/simulated/floor/mech_bay_recharge_floor,
+/area/syndicate_mothership)
+"Rp" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion_r";
+	tag = "icon-propulsion_r"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate)
+"Rr" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "adminshuttle";
+	name = "Workshop";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Rw" = (
+/obj/item/flag/syndi,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "wood"
+	},
+/area/syndicate_mothership)
 "Rx" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/o2{
@@ -12920,18 +15344,157 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"Rz" = (
+/obj/machinery/computer/shuttle/admin{
+	name = "NTV Argos shuttle console"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"RC" = (
+/turf/simulated/shuttle/wall{
+	dir = 8;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/vox)
 "RD" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/centcom/control)
+"RH" = (
+/obj/machinery/door/airlock/public/glass,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"RK" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/light/spot,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"RL" = (
+/obj/machinery/vending/boozeomat,
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/shuttle/administration)
+"RM" = (
+/turf/unsimulated/wall/fakeglass{
+	dir = 5;
+	icon_state = "fakewindows";
+	tag = "icon-fakewindows (NORTHEAST)"
+	},
+/area/syndicate_mothership/jail)
+"RN" = (
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Secure Storage";
+	req_access_txt = "150"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"RP" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "open";
+	id_tag = "voxshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 8;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_end";
+	tag = "icon-window5_end (WEST)"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"RR" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"RT" = (
+/obj/machinery/door/window{
+	dir = 2;
+	name = "Cockpit";
+	req_access_txt = "150"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"RU" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swallc2"
+	},
+/area/shuttle/trade/sol)
+"RW" = (
+/obj/machinery/light/spot,
+/turf/simulated/shuttle/floor,
+/area/shuttle/supply)
+"RY" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/transport)
+"RZ" = (
+/obj/effect/spawner/lootdrop/trade_sol/civ,
+/obj/structure/closet,
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
 "Sa" = (
 /obj/structure/chair/office/dark,
 /turf/unsimulated/floor{
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"Sb" = (
+/obj/structure/computerframe,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Sd" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/vox,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Sg" = (
+/obj/structure/window/full/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "trader_privacy";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/trade/sol)
+"Sh" = (
+/obj/machinery/vending/syndisnack,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"Si" = (
+/obj/structure/table/wood,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
 "Sj" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -12943,6 +15506,65 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"Sl" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"So" = (
+/obj/structure/table,
+/obj/item/bonegel,
+/obj/item/bonesetter,
+/obj/item/hemostat,
+/obj/item/cautery,
+/obj/item/surgicaldrill,
+/obj/item/circular_saw,
+/obj/item/scalpel,
+/obj/item/retractor,
+/obj/item/FixOVein,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
+"Sp" = (
+/obj/item/storage/toolbox/syndicate,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Ss" = (
+/turf/simulated/shuttle/wall{
+	dir = 8;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/administration)
+"Su" = (
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "adminshuttleblast";
+	name = "Blast Doors";
+	req_access_txt = "101"
+	},
+/obj/machinery/door/airlock/centcom{
+	id_tag = "adminshuttle";
+	name = "General Access";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Sw" = (
+/obj/effect/landmark{
+	name = "syndieprisonwarp"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"Sz" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
 "SA" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Cell";
@@ -12951,6 +15573,15 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
+"SD" = (
+/obj/effect/landmark{
+	name = "Nuclear-Bomb"
+	},
+/obj/machinery/light/spot,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "SH" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/light/spot{
@@ -12960,6 +15591,39 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
+"SI" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/trade/sol)
+"SK" = (
+/obj/item/radio/intercom/syndicate{
+	pixel_y = -28
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"SN" = (
+/obj/machinery/airlock_sensor{
+	frequency = 1331;
+	id_tag = "vox_west_sensor";
+	pixel_x = 25;
+	req_access_txt = "152"
+	},
+/obj/machinery/light/spot{
+	dir = 4;
+	icon_state = "tube1";
+	tag = "icon-tube1 (EAST)"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"SO" = (
+/obj/structure/closet/crate,
+/turf/simulated/shuttle/floor,
+/area/shuttle/transport)
 "SQ" = (
 /turf/simulated/shuttle/wall{
 	dir = 2;
@@ -12967,6 +15631,36 @@
 	tag = "icon-swall14"
 	},
 /area/shuttle/escape)
+"SS" = (
+/obj/machinery/door/airlock/hatch{
+	frequency = 1331;
+	icon_state = "door_locked";
+	id_tag = "vox_southeast_lock";
+	locked = 1;
+	req_access_txt = "152";
+	req_one_access = null;
+	req_one_access_txt = "0"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"ST" = (
+/obj/machinery/door/airlock/hatch{
+	frequency = 1331;
+	icon_state = "door_locked";
+	id_tag = "vox_northwest_lock";
+	locked = 1;
+	req_access_txt = "152";
+	req_one_access = null;
+	req_one_access_txt = "0"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"SV" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
 "SX" = (
 /obj/machinery/light/spot{
 	dir = 1;
@@ -12975,6 +15669,12 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
+"SY" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
 "Te" = (
 /obj/machinery/teleport/hub/upgraded{
 	admin_usage = 1
@@ -13008,6 +15708,14 @@
 	icon_state = "floor"
 	},
 /area/centcom/control)
+"Tj" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
 "Tl" = (
 /obj/structure/chair/office/dark,
 /turf/unsimulated/floor{
@@ -13022,6 +15730,146 @@
 	icon_state = "floor"
 	},
 /area/centcom/control)
+"Tq" = (
+/obj/machinery/light/small{
+	dir = 4;
+	icon_state = "bulb1";
+	tag = "icon-bulb1 (EAST)"
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/assault_pod)
+"Ts" = (
+/obj/item/skeleton/r_arm,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Tu" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "open";
+	id_tag = "adminshuttleshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 4;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_mid";
+	tag = "icon-window5 (EAST)"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/administration)
+"Tx" = (
+/obj/effect/spawner/lootdrop/trade_sol/sci,
+/obj/structure/closet,
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"Ty" = (
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"Tz" = (
+/turf/simulated/shuttle/wall{
+	dir = 1;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/syndicate)
+"TA" = (
+/obj/structure/table,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"TB" = (
+/obj/machinery/door/window/northright{
+	name = "bar"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"TC" = (
+/turf/unsimulated/wall/fakeglass{
+	dir = 9;
+	icon_state = "fakewindows";
+	tag = "icon-fakewindows (NORTHWEST)"
+	},
+/area/syndicate_mothership)
+"TH" = (
+/obj/structure/flora/bush,
+/turf/space,
+/turf/unsimulated/floor/snow,
+/area/syndicate_mothership)
+"TI" = (
+/obj/machinery/computer/communications,
+/obj/item/radio/intercom/specops{
+	pixel_y = -28
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/specops)
+"TK" = (
+/obj/machinery/door/airlock/hatch/syndicate,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
+"TM" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall14"
+	},
+/area/shuttle/trade/sol)
+"TO" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1331;
+	master_tag = "vox_east_control";
+	req_one_access_txt = "152"
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/shuttle/vox)
+"TR" = (
+/turf/space,
+/turf/space,
+/turf/unsimulated/wall/fakeglass{
+	dir = 8;
+	icon_state = "fakewindows2";
+	tag = "icon-fakewindows2 (WEST)"
+	},
+/area/syndicate_mothership)
+"TS" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "open";
+	id_tag = "voxshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 4;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_mid";
+	tag = "icon-window5 (EAST)"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
 "TT" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -13035,6 +15883,18 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/escape)
+"TV" = (
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"TX" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 0
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "Uf" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -13043,6 +15903,70 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"Ug" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "freezerfloor"
+	},
+/area/syndicate_mothership)
+"Uh" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Infirmary";
+	req_access_txt = "150"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Uj" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/optable,
+/obj/item/organ/internal/brain,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Uk" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion_l";
+	tag = "icon-propulsion_l"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/syndicate)
+"Un" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Up" = (
+/obj/structure/table,
+/obj/item/radio/beacon/syndicate/bomb{
+	pixel_y = 5
+	},
+/obj/item/radio/beacon/syndicate/bomb,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Ur" = (
+/obj/machinery/teleport/station,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "Ut" = (
 /turf/simulated/shuttle/wall{
 	dir = 2;
@@ -13050,6 +15974,15 @@
 	tag = "icon-swall_f10"
 	},
 /area/shuttle/escape)
+"Uu" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/weed_extract,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
 "Uw" = (
 /obj/machinery/door/airlock/shuttle{
 	aiControlDisabled = 1;
@@ -13070,10 +16003,47 @@
 	icon_state = "floor2"
 	},
 /area/shuttle/escape)
+"UA" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "open";
+	id_tag = "adminshuttleshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 4;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_end";
+	tag = "icon-window5_end (EAST)"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/administration)
 "UC" = (
 /obj/machinery/light/spot,
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
+"UD" = (
+/obj/structure/table,
+/obj/machinery/door_control{
+	id = "syndieshutters";
+	name = "remote shutter control";
+	req_access_txt = "150"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"UE" = (
+/obj/structure/table,
+/obj/item/weldingtool/largetank,
+/obj/item/multitool,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "UF" = (
 /turf/simulated/shuttle/wall{
 	dir = 2;
@@ -13081,6 +16051,18 @@
 	tag = "icon-swall_f9"
 	},
 /area/shuttle/escape)
+"UG" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the Special Ops team.";
+	name = "Spec Ops Monitor";
+	network = list("ERT");
+	pixel_y = 30
+	},
+/obj/machinery/computer/shuttle/ert,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/specops)
 "UH" = (
 /obj/structure/chair{
 	dir = 1
@@ -13089,12 +16071,139 @@
 	icon_state = "grimy"
 	},
 /area/centcom/specops)
+"UL" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/shuttle/plating,
+/area/shuttle/supply)
 "UN" = (
 /obj/machinery/light/spot,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"UT" = (
+/obj/machinery/light{
+	dir = 1;
+	on = 1
+	},
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
+"UV" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall_f9"
+	},
+/area/shuttle/transport)
+"UX" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "syndicate_away";
+	req_access_txt = "150"
+	},
+/turf/space,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
+"UY" = (
+/obj/machinery/porta_turret/syndicate/pod,
+/turf/simulated/shuttle/wall{
+	dir = 8;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/assault_pod)
+"UZ" = (
+/obj/machinery/atmospherics/unary/tank/nitrogen{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Ve" = (
+/turf/simulated/shuttle/floor,
+/area/shuttle/supply)
+"Vg" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Vi" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/red,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"Vm" = (
+/obj/structure/table,
+/obj/item/storage/box/syndidonkpockets,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Vo" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Equipment Room";
+	req_access_txt = "150"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Vq" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/pickaxe,
+/obj/item/storage/firstaid/toxin,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Vr" = (
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"Vu" = (
+/turf/unsimulated/wall/fakeglass{
+	dir = 8;
+	icon_state = "fakewindows"
+	},
+/area/syndicate_mothership/jail)
+"Vv" = (
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
+/obj/structure/table,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Vw" = (
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/shuttle/floor,
+/area/shuttle/transport)
+"Vx" = (
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
 "VA" = (
 /obj/effect/decal/warning_stripes/northwest,
 /turf/unsimulated/floor{
@@ -13125,12 +16234,69 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"VG" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1331;
+	id_tag = "synd_airlock";
+	pixel_x = 25;
+	req_access_txt = "150";
+	tag_airpump = "synd_pump";
+	tag_chamber_sensor = "synd_sensor";
+	tag_exterior_door = "synd_outer";
+	tag_interior_door = "synd_inner"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1331;
+	id_tag = "synd_sensor";
+	pixel_x = 25;
+	pixel_y = 12;
+	req_access_txt = "150"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"VH" = (
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
+	},
+/obj/machinery/suit_storage_unit/syndicate/secure,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 "VJ" = (
 /obj/structure/chair,
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
 /area/centcom/evac)
+"VN" = (
+/obj/effect/decal/warning_stripes/southeast,
+/turf/space,
+/turf/space,
+/turf/simulated/floor/plating/airless,
+/area/syndicate_mothership)
+"VS" = (
+/turf/simulated/shuttle/wall{
+	dir = 4;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/syndicate)
+"VT" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "150"
+	},
+/turf/simulated/floor/plating,
+/area/syndicate_mothership)
 "VX" = (
 /obj/machinery/door/airlock/shuttle{
 	aiControlDisabled = 1;
@@ -13148,6 +16314,21 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"Wc" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 32
+	},
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/specops)
 "Wd" = (
 /obj/structure/chair{
 	dir = 8
@@ -13168,6 +16349,18 @@
 /obj/structure/chair/stool,
 /turf/simulated/shuttle/floor,
 /area/centcom/evac)
+"Wi" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Wj" = (
+/obj/structure/closet/crate,
+/obj/machinery/light/spot,
+/turf/simulated/shuttle/floor,
+/area/shuttle/transport)
 "Wk" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -13184,23 +16377,123 @@
 	icon_state = "floor4"
 	},
 /area/centcom/evac)
+"Wn" = (
+/obj/item/clothing/head/bearpelt,
+/obj/item/xenos_claw,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Wo" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/syndicate{
+	pixel_x = 5
+	},
+/obj/item/multitool{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/multitool,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"Wp" = (
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/supply)
+"Wu" = (
+/obj/item/radio/intercom/syndicate{
+	pixel_x = -28
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Ww" = (
+/obj/item/radio/intercom/syndicate{
+	pixel_x = 0;
+	pixel_y = 25
+	},
+/obj/item/twohanded/required/kirbyplants,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
+"Wx" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "voxshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 2;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_end";
+	tag = "icon-window5_end"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
 "Wy" = (
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
 /area/shuttle/escape)
+"WA" = (
+/obj/structure/table/wood,
+/obj/machinery/kitchen_machine/microwave,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"WD" = (
+/turf/unsimulated/wall/fakeglass,
+/area/syndicate_mothership)
 "WE" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"WF" = (
+/turf/unsimulated/floor/snow{
+	dir = 5;
+	icon_state = "gravsnow_corner";
+	tag = "icon-gravsnow_corner (NORTHEAST)"
+	},
+/turf/unsimulated/floor/snow,
+/area/syndicate_mothership)
+"WH" = (
+/obj/structure/chair/stool,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
 "WI" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/simulated/shuttle/floor,
 /area/centcom/evac)
+"WO" = (
+/obj/machinery/chem_dispenser,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
+"WS" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
 "WU" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/shuttle/floor,
@@ -13212,6 +16505,45 @@
 	name = "grass"
 	},
 /area/centcom/control)
+"WX" = (
+/obj/machinery/light/spot,
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"WY" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/vox)
+"Xf" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "soltradeship_south";
+	name = "Security Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/shuttle/glass{
+	id_tag = "soltrader_south";
+	name = "trader shuttle airlock";
+	req_access_txt = "160";
+	security_level = 6
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"Xh" = (
+/obj/structure/sign/double/map/left{
+	pixel_y = -32
+	},
+/obj/machinery/light,
+/obj/structure/rack/skeletal_bar/left,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "wood"
+	},
+/area/syndicate_mothership)
 "Xj" = (
 /obj/structure/bed,
 /turf/unsimulated/floor{
@@ -13224,6 +16556,21 @@
 	icon_state = "floor"
 	},
 /area/centcom)
+"Xo" = (
+/obj/machinery/door/airlock/shuttle/glass{
+	name = "trader shuttle airlock";
+	req_access_txt = "160";
+	security_level = 6
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"Xp" = (
+/turf/space,
+/turf/unsimulated/wall/fakeglass{
+	dir = 1;
+	icon_state = "fakewindows"
+	},
+/area/syndicate_mothership)
 "Xr" = (
 /obj/structure/bed,
 /turf/unsimulated/floor{
@@ -13238,6 +16585,18 @@
 	},
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/shuttle/escape)
+"XA" = (
+/turf/simulated/shuttle/wall{
+	dir = 1;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/vox)
+"XD" = (
+/obj/machinery/computer/card,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
 "XF" = (
 /obj/machinery/door/airlock/shuttle{
 	aiControlDisabled = 1;
@@ -13247,6 +16606,18 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
+"XG" = (
+/obj/machinery/vending/syndisnack,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
+"XI" = (
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c500,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
 "XL" = (
 /obj/structure/table/abductor,
 /obj/item/bonegel/alien,
@@ -13260,6 +16631,383 @@
 /obj/structure/bed/abductor,
 /turf/unsimulated/floor/abductor,
 /area/abductor_ship)
+"XN" = (
+/turf/unsimulated/wall/fakeglass{
+	dir = 1;
+	icon_state = "fakewindows"
+	},
+/area/syndicate_mothership/jail)
+"XO" = (
+/obj/item/stack/sheet/metal,
+/obj/structure/table,
+/obj/item/stack/sheet/glass{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"XT" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall12";
+	tag = "icon-swall12"
+	},
+/area/shuttle/supply)
+"XW" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark{
+	name = "syndieprisonwarp"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"Yb" = (
+/obj/effect/decal/warning_stripes/northeastcorner,
+/turf/simulated/floor/plating/airless,
+/area/syndicate_mothership)
+"Yc" = (
+/obj/machinery/light,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Yd" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Yi" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/ert,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/specops)
+"Yo" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Yp" = (
+/obj/structure/table,
+/obj/item/screwdriver{
+	pixel_y = 9
+	},
+/obj/item/assembly/voice{
+	pixel_y = 3
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Yq" = (
+/turf/simulated/shuttle/wall{
+	dir = 8;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/syndicate)
+"Yr" = (
+/obj/effect/spawner/lootdrop/trade_sol/vehicle,
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"Ys" = (
+/obj/machinery/door_control{
+	id = "soltrader_north";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = -8;
+	req_access_txt = "160"
+	},
+/obj/machinery/door_control{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_x = 24;
+	pixel_y = 8;
+	req_access_txt = "160"
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"Yt" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/broken_device,
+/obj/item/robot_parts/chest,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"Yy" = (
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/assembly/infra,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"Yz" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"YC" = (
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "voxshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/shuttle/window{
+	dir = 1;
+	icon = 'icons/turf/shuttle.dmi';
+	icon_state = "window5_end";
+	tag = "icon-window5_end (NORTH)"
+	},
+/turf/simulated/shuttle/plating/vox,
+/area/shuttle/vox)
+"YD" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "heater"
+	},
+/turf/unsimulated/floor,
+/area/shuttle/specops)
+"YE" = (
+/turf/simulated/shuttle/wall{
+	dir = 1;
+	icon_state = "diagonalWall3"
+	},
+/area/shuttle/specops)
+"YK" = (
+/obj/structure/table,
+/obj/item/storage/fancy/crayons,
+/obj/item/storage/fancy/crayons,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "freezerfloor"
+	},
+/area/syndicate_mothership)
+"YL" = (
+/obj/structure/computerframe,
+/obj/item/paper/synditele,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"YN" = (
+/obj/machinery/bodyscanner,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"YO" = (
+/obj/machinery/computer/mech_bay_power_console,
+/turf/unsimulated/floor,
+/area/syndicate_mothership)
+"YQ" = (
+/obj/structure/table,
+/obj/item/storage/box/handcuffs,
+/obj/machinery/light/spot{
+	dir = 8;
+	icon_state = "tube1";
+	tag = "icon-tube1 (WEST)"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"YR" = (
+/obj/machinery/computer/shuttle/syndicate/recall,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "wood"
+	},
+/area/syndicate_mothership)
+"YT" = (
+/obj/machinery/door/window/westright{
+	name = "Tool Storage";
+	req_access_txt = "150"
+	},
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"YU" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/scalpel,
+/obj/item/stack/cable_coil,
+/obj/item/storage/firstaid/regular,
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
+"YW" = (
+/obj/machinery/door/poddoor{
+	id_tag = "nukeop_ready";
+	name = "Shuttle Dock Door"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"YY" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0
+	},
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/shuttle/syndicate)
+"Za" = (
+/obj/machinery/mecha_part_fabricator/upgraded,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Zb" = (
+/obj/machinery/light/spot{
+	dir = 1;
+	icon_state = "tube1";
+	tag = "icon-tube1 (NORTH)"
+	},
+/obj/machinery/door_control{
+	id = "adminshuttleblast";
+	name = "Blast door control";
+	pixel_x = -5;
+	pixel_y = 35;
+	req_access = list(101);
+	req_access_txt = "0"
+	},
+/obj/machinery/door_control{
+	id = "adminshuttleshutters";
+	name = "Shutter control";
+	pixel_x = 5;
+	pixel_y = 35;
+	req_access = list(101);
+	req_access_txt = "0"
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/administration)
+"Zd" = (
+/obj/docking_port/stationary{
+	area_type = /area/syndicate_mothership;
+	dir = 1;
+	dwidth = 11;
+	height = 18;
+	id = "emergency_syndicate";
+	name = "404 Not Found";
+	turf_type = /turf/unsimulated/floor/snow;
+	width = 29
+	},
+/turf/space,
+/turf/unsimulated/floor/snow,
+/area/syndicate_mothership)
+"Ze" = (
+/obj/effect/spawner/lootdrop/trade_sol/minerals,
+/obj/structure/closet,
+/turf/simulated/shuttle/floor,
+/area/shuttle/trade/sol)
+"Zh" = (
+/obj/structure/plasticflaps/mining,
+/obj/machinery/conveyor/west{
+	id = "QMLoad"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/supply)
+"Zk" = (
+/obj/machinery/washing_machine,
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "freezerfloor"
+	},
+/area/syndicate_mothership)
+"Zl" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/mushroompizzaslice{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/unsimulated/floor{
+	dir = 2;
+	icon_state = "bar"
+	},
+/area/syndicate_mothership)
+"Zp" = (
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	frequency = 1441;
+	id_tag = "syndicate_jail_airlock_control";
+	name = "Syndicate Jail Access Controller";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access_txt = "150";
+	tag_exterior_door = "syndicate_jail_airlock_external";
+	tag_interior_door = "syndicate_jail_airlock_internal"
+	},
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership)
+"Zq" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "wall3"
+	},
+/area/shuttle/administration)
+"Zu" = (
+/obj/effect/decal/cleanable/blood,
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"Zv" = (
+/obj/structure/flora/tree/pine{
+	pixel_x = 1
+	},
+/turf/space,
+/turf/unsimulated/floor/snow,
+/area/syndicate_mothership)
+"Zy" = (
+/obj/machinery/light/spot,
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
+"ZA" = (
+/obj/machinery/computer/shuttle/ferry/request,
+/turf/simulated/shuttle/floor,
+/area/shuttle/transport)
 "ZB" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle{
@@ -13278,6 +17026,35 @@
 	icon_state = "floor3"
 	},
 /area/shuttle/escape)
+"ZM" = (
+/turf/simulated/shuttle/wall{
+	dir = 2;
+	icon_state = "swall_f10"
+	},
+/area/shuttle/trade/sol)
+"ZS" = (
+/turf/unsimulated/floor{
+	icon_state = "dark"
+	},
+/area/syndicate_mothership/jail)
+"ZY" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1331;
+	icon_state = "door_locked";
+	id_tag = "synd_inner";
+	locked = 1;
+	name = "Ship External Access";
+	req_access = null;
+	req_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
+	},
+/area/shuttle/syndicate)
 
 (1,1,1) = {"
 ck
@@ -30132,11 +33909,11 @@ sX
 sX
 aN
 aN
-aN
-aN
-aN
-aN
-aN
+FP
+zp
+zp
+zp
+OE
 sX
 aN
 aN
@@ -30389,11 +34166,11 @@ pV
 sX
 aN
 aN
-aN
-aN
-aN
-aN
-aN
+KG
+YD
+YD
+YD
+KG
 sX
 aN
 aN
@@ -30646,11 +34423,11 @@ pW
 sX
 aN
 aN
-aN
-aN
-aN
-aN
-aN
+KG
+UG
+Lj
+TI
+KG
 sX
 aN
 aN
@@ -30903,11 +34680,11 @@ uj
 sX
 aN
 aN
-aN
-aN
-aN
-aN
-aN
+KG
+Yi
+Hq
+KQ
+KG
 sX
 aN
 aN
@@ -31160,11 +34937,11 @@ uj
 sX
 qj
 wr
-aN
-aN
-aN
-aN
-aN
+KG
+LN
+Hq
+Eb
+KG
 sX
 aN
 aN
@@ -31417,11 +35194,11 @@ uj
 qd
 VA
 VD
-aN
-aN
-aN
-aN
-aN
+OC
+Hq
+Hq
+Eb
+KG
 sX
 aN
 aN
@@ -31674,11 +35451,11 @@ uj
 qd
 VB
 VE
-aN
-aN
-aN
-aN
-aN
+OC
+Hq
+Hq
+Eb
+KG
 sX
 aN
 aN
@@ -31931,11 +35708,11 @@ vL
 sX
 qj
 wr
-aN
-aN
-aN
-aN
-aN
+KG
+Go
+Hq
+Eb
+KG
 sX
 aN
 aN
@@ -32188,11 +35965,11 @@ Ga
 sX
 we
 we
-aN
-aN
-aN
-aN
-aN
+KG
+Wc
+Hq
+Eb
+KG
 sX
 aN
 aN
@@ -32445,11 +36222,11 @@ sX
 sX
 sX
 sX
-aN
-aN
-aN
-aN
-aN
+YE
+KG
+Hq
+KG
+Ow
 sX
 aN
 aN
@@ -32703,9 +36480,9 @@ vS
 qk
 sX
 aN
-aN
+YE
 rb
-aN
+Ow
 aN
 sX
 aN
@@ -33756,17 +37533,17 @@ aN
 aN
 aN
 qI
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Jn
+Nq
+Nq
+Nq
+Nq
+Nq
+Nq
+Nq
+Nq
+Nq
+pn
 aN
 qI
 aN
@@ -34013,18 +37790,18 @@ cj
 cj
 cj
 qI
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+XT
+Ve
+Ve
+Ve
+Ve
+Ax
+Ve
+Ve
+Ve
+Ve
+XT
+Fu
 qI
 aN
 aN
@@ -34262,26 +38039,26 @@ aN
 aN
 cj
 cp
-cp
-cr
-aN
-cr
-cp
+LL
+Iv
+Iv
+Iv
+Ck
 cp
 cj
 qI
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+XT
+Ve
+Ve
+Ve
+Ve
+Ve
+Ve
+Ve
+Ve
+Ve
+qv
+UL
 qI
 aN
 aN
@@ -34520,25 +38297,25 @@ aN
 cj
 cp
 cr
-aN
-aN
-aN
+Gp
+NZ
+Wj
 cr
 cp
 cj
 qI
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+XT
+Wp
+Ve
+Ve
+Ve
+Ve
+Ve
+Ve
+Ve
+RW
+qv
+UL
 qI
 aN
 aN
@@ -34776,26 +38553,26 @@ aN
 aN
 cj
 cp
-aN
-aN
-aN
-aN
-aN
+cr
+ZA
+NZ
+SO
+cr
 cp
 cj
 qI
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+XT
+Ve
+Ve
+Ve
+Ve
+Ve
+Ve
+Ve
+Ve
+Ve
+qv
+UL
 qI
 aN
 aN
@@ -35033,26 +38810,26 @@ aN
 aN
 cj
 cp
-aN
-aN
-aN
-aN
-aN
+cr
+HF
+NZ
+RY
+cr
 cp
 cj
 qI
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+XT
+Ve
+Ve
+Ve
+Ve
+CA
+Ve
+Ve
+Ve
+Ve
+XT
+EG
 qI
 aN
 aN
@@ -35290,25 +39067,25 @@ aN
 aN
 cj
 cp
-aN
-aN
-aN
-aN
-aN
+JS
+HF
+NZ
+RY
+JS
 cp
 cj
 qI
-aN
-aN
-aN
-aN
-aN
-aN
+Kz
+Nq
+Nq
+Gd
+yE
+Nq
 tW
-aN
-aN
-aN
-aN
+Zh
+Nq
+Nq
+Df
 aN
 qI
 aN
@@ -35547,11 +39324,11 @@ aN
 aN
 cj
 cp
-aN
-aN
-aN
-aN
-aN
+cr
+HF
+NZ
+RY
+cr
 cp
 cj
 qI
@@ -35804,11 +39581,11 @@ wK
 wK
 cj
 cp
-aN
-aN
-aN
-aN
-aN
+cr
+Vw
+NZ
+ER
+cr
 cp
 cj
 aN
@@ -35830,9 +39607,9 @@ wK
 wK
 wK
 wK
-bZ
-bZ
-bZ
+wK
+wK
+wK
 aN
 aN
 aN
@@ -36061,11 +39838,11 @@ sz
 sz
 cj
 cp
-aN
-aN
-aN
-aN
-aN
+cr
+HF
+NZ
+RY
+cr
 cp
 cj
 aN
@@ -36074,22 +39851,22 @@ wK
 aN
 aN
 aN
+Ss
+LI
+mG
+Mi
+aN
+Ss
+LI
+mG
+Mi
 aN
 aN
 aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -36318,11 +40095,11 @@ sr
 sr
 cj
 cp
-aN
-aN
-aN
-aN
-aN
+qn
+HF
+NZ
+RY
+qn
 cp
 cj
 aN
@@ -36330,23 +40107,23 @@ aN
 wK
 aN
 aN
+Ss
+Zq
+OJ
+OJ
+Zq
+Zq
+Zq
+OJ
+OJ
+Zq
+Mi
 aN
 aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -36575,35 +40352,35 @@ sA
 sr
 cj
 cp
-aN
-aN
-aN
-aN
-aN
+cr
+HF
+NZ
+RY
+cr
 cp
 cj
 aN
 aN
 wK
 aN
+Ss
+Zq
+FM
+NK
+NK
+ID
+Zq
+GM
+IG
+IG
+qs
+Zq
+Mi
 aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -36832,35 +40609,35 @@ ss
 sr
 cj
 cp
-aN
-aN
-aN
-aN
-aN
+cr
+Vw
+NZ
+ER
+cr
 cp
 cj
 aN
 aN
 wK
+Ss
+RL
+NK
+TB
+NK
+NK
+IY
+Zq
+QJ
+IG
+IG
+IG
+Id
+Zq
+Mi
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -37089,35 +40866,35 @@ sr
 sr
 cj
 cp
-cr
-aN
+zo
+JS
 tb
-aN
-cr
+JS
+UV
 cp
 cj
 aN
 aN
 wK
+Zq
+Lz
+NK
+TA
+PY
+NK
+RK
+Zq
+Na
+IG
+IG
+IG
+IG
+So
+Zq
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -37356,25 +41133,25 @@ cj
 aN
 aN
 wK
+Zq
+Cn
+NK
+Da
+PY
+NK
+WS
+Zq
+GM
+IG
+GW
+Gj
+IG
+HO
+Zq
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -37613,25 +41390,25 @@ cj
 wK
 wK
 wK
+Zq
+OF
+KZ
+pp
+PY
+NK
+NK
+Zq
+Mq
+IG
+IG
+WO
+Fi
+KS
+Zq
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -37870,25 +41647,25 @@ yt
 yt
 yt
 wK
+Zq
+IW
+IW
+IW
+IW
+RH
+IW
+IW
+IW
+Cx
+IW
+IW
+IW
+IW
+Zq
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -38127,25 +41904,25 @@ yt
 yt
 yt
 pg
+MH
+Gc
+Su
+Jh
+NK
+NK
+NK
+Gi
+NK
+NK
+NK
+NK
+NK
+NK
+Zq
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -38385,24 +42162,24 @@ yt
 yt
 pg
 tH
+NK
+Su
+NK
+NK
+NK
+NK
+NK
+NK
+NK
+NK
+NK
+NK
+Yc
+Zq
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -38641,25 +42418,25 @@ yt
 yt
 ko
 wK
+Zq
+IW
+IW
+Rr
+IW
+IW
+IW
+CK
+IW
+IW
+IW
+Dd
+IW
+IW
+Zq
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -38898,25 +42675,25 @@ wK
 bZ
 wK
 wK
+Zq
+DZ
+Gi
+NK
+MI
+Zq
+XD
+NK
+NK
+Zq
+NK
+NK
+YQ
+LC
+Zq
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -39155,25 +42932,25 @@ to
 to
 nb
 wK
+Zq
+Vv
+NK
+NK
+CO
+Zq
+Zb
+Yd
+Yd
+Zq
+NK
+NK
+NK
+LE
+Zq
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -39412,25 +43189,25 @@ tp
 kc
 nX
 wK
+Zq
+FS
+NK
+NK
+LU
+Zq
+Qu
+Rz
+Em
+Zq
+NK
+NK
+NK
+NK
+Zq
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -39461,15 +43238,15 @@ aN
 aN
 aN
 mr
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+MZ
+Cl
+SI
+Cl
+SI
+Mp
+SI
+Mp
+DH
 mr
 aN
 aN
@@ -39669,25 +43446,25 @@ qo
 kg
 nZ
 wK
+OV
+Zq
+XO
+NK
+NK
+Zq
+Ms
+Tu
+UA
+Zq
+EQ
+DV
+Vx
+Zq
+CM
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -39718,15 +43495,15 @@ aN
 aN
 aN
 mr
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+TM
+Cz
+Cz
+Cz
+Cz
+Cz
+Cz
+Cz
+Oc
 mr
 aN
 aN
@@ -39927,24 +43704,24 @@ kg
 oa
 wK
 aN
+Zq
+Za
+NK
+IR
+Zq
+aN
+aN
+aN
+Zq
+NK
+NK
+HH
+Zq
 aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -39975,15 +43752,15 @@ aN
 aN
 aN
 mr
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Ji
+RZ
+Vr
+Tx
+Vr
+CG
+Vr
+Mz
+Ji
 mr
 aN
 aN
@@ -40184,24 +43961,24 @@ kh
 oZ
 wK
 aN
+OV
+Zq
+KZ
+Pu
+Zq
+aN
+aN
+aN
+Zq
+QV
+En
+Zq
+CM
 aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -40232,15 +44009,15 @@ aN
 aN
 aN
 mr
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Sg
+Ze
+Vr
+Mf
+Vr
+zG
+Vr
+Yr
+Sg
 mr
 zn
 zn
@@ -40442,23 +44219,23 @@ wK
 wK
 aN
 aN
+OV
+IW
+IW
+CM
+aN
+aN
+aN
+OV
+IW
+IW
+CM
 aN
 aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-nY
-aN
-aN
-bZ
+wK
 aN
 aN
 aN
@@ -40489,15 +44266,15 @@ aN
 aN
 aN
 mr
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Ji
+Nr
+Vr
+Vr
+Vr
+Vr
+Vr
+Jv
+Ji
 mr
 fZ
 fZ
@@ -40712,10 +44489,10 @@ aN
 aN
 aN
 aN
-nY
 aN
 aN
-bZ
+aN
+wK
 aN
 aN
 aN
@@ -40746,15 +44523,15 @@ aN
 aN
 aN
 mr
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Ji
+Vr
+Vr
+Vr
+Vr
+Vr
+HG
+Vr
+Ji
 mr
 fL
 yF
@@ -40970,9 +44747,9 @@ wK
 wK
 wK
 wK
-bZ
-bZ
-bZ
+wK
+wK
+wK
 aN
 aN
 aN
@@ -41003,15 +44780,15 @@ aN
 aN
 aN
 mr
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Ji
+Vr
+Ys
+HG
+HG
+HG
+CN
+Vr
+Ji
 mr
 yF
 yF
@@ -41260,15 +45037,15 @@ aN
 aN
 aN
 mr
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Ji
+Xo
+RU
+Lx
+Lx
+Lx
+Dm
+Xo
+Ji
 mr
 yF
 yF
@@ -41517,15 +45294,15 @@ aN
 aN
 aN
 mr
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Ji
+Vr
+Oj
+LF
+Ec
+Eu
+Oj
+Vr
+Ji
 mr
 yF
 yF
@@ -41774,15 +45551,15 @@ aN
 aN
 aN
 mr
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Sg
+Ty
+IA
+Vr
+Vr
+Vr
+Xf
+WX
+Sg
 mr
 yF
 yF
@@ -42031,15 +45808,15 @@ aN
 aN
 aN
 mr
-aN
-aN
-aN
-aN
+ZM
+Cz
+Cz
+GJ
 fw
-aN
-aN
-aN
-aN
+GJ
+Cz
+Cz
+DR
 mr
 yF
 zj
@@ -43067,18 +46844,18 @@ at
 at
 at
 at
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+RC
+Nx
+Nx
+Nx
+LY
+LY
+RP
+TS
+ty
+Nx
+Nx
+EE
 aN
 aN
 aN
@@ -43324,18 +47101,18 @@ at
 bl
 bl
 bl
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+FZ
+Nh
+Nh
+Pw
+Nh
+Nh
+Nh
+TV
+TV
+UZ
+WY
+PH
 aN
 aN
 aN
@@ -43581,18 +47358,18 @@ bk
 bl
 bl
 bl
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+ST
+SN
+JY
+KL
+LY
+LY
+Nh
+Ls
+TV
+OT
+WY
+PH
 aN
 aN
 aN
@@ -43838,18 +47615,18 @@ at
 at
 at
 at
+XA
+Nx
+Nx
+JR
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+LY
+Nh
+Uu
+TV
+Fw
+LY
+JR
 aN
 aN
 aN
@@ -44100,12 +47877,12 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
+LY
+Nh
+PN
+TV
+Ks
+LY
 aN
 aN
 aN
@@ -44354,15 +48131,15 @@ aN
 at
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+RC
+RP
+ty
+LY
+Nh
+Yt
+Sp
+QR
+LY
 aN
 aN
 aN
@@ -44610,22 +48387,22 @@ aN
 aN
 at
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+RC
+LY
+Yo
+Yo
+LY
+Nh
+Nx
+Nx
+Nx
+Nx
+Nx
+Nx
+Nx
+Nx
+Nx
+EE
 aN
 at
 aN
@@ -44866,24 +48643,24 @@ at
 aN
 aN
 at
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+RC
+Nx
+TV
+TV
+TV
+LY
+Nh
+Hc
+TV
+Gs
+Mr
+JF
+LD
+EF
+Ka
+Lc
+LY
+EE
 at
 aN
 aN
@@ -45124,23 +48901,23 @@ aN
 aN
 at
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Wx
+Sd
+TV
+LK
+LY
+Nx
+LY
+TV
+TV
+TV
+TV
+TV
+HB
+Sl
+Qj
+tE
+LY
 at
 aN
 aN
@@ -45381,23 +49158,23 @@ aN
 aN
 at
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Pa
+MC
+Sz
+Ea
+Hc
+IE
+Hc
+TV
+TV
+TV
+TV
+TV
+Hc
+TV
+TV
+Ci
+LY
 at
 aN
 aN
@@ -45638,23 +49415,23 @@ aN
 aN
 at
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+YC
+Pr
+TV
+TV
+LY
+Nx
+LY
+TV
+TV
+TV
+TV
+TV
+EF
+Km
+XI
+Py
+LY
 at
 aN
 aN
@@ -45894,24 +49671,24 @@ at
 aN
 aN
 at
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+XA
+Nx
+TV
+TV
+TV
+LY
+Nh
+Hc
+TV
+LM
+MY
+Ou
+Ou
+HB
+Wn
+Ne
+LY
+JR
 at
 aN
 aN
@@ -46152,22 +49929,22 @@ aN
 aN
 at
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+XA
+LY
+SY
+SY
+LY
+Nh
+Nx
+Nx
+Nx
+Nx
+Nx
+Nx
+Nx
+Nx
+Nx
+JR
 aN
 at
 aN
@@ -46410,15 +50187,15 @@ aN
 at
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+XA
+Er
+PM
+LY
+Nh
+Vq
+TV
+OQ
+LY
 aN
 aN
 aN
@@ -46670,12 +50447,12 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
+LY
+Nh
+YU
+TV
+TV
+LY
 aN
 aN
 aN
@@ -46922,18 +50699,18 @@ at
 at
 at
 at
+RC
+Nx
+Nx
+EE
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+LY
+Nh
+Ie
+Ts
+Iz
+LY
+EE
 aN
 aN
 aN
@@ -47180,17 +50957,17 @@ bl
 bl
 bl
 zT
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Jp
+QS
+TO
+LY
+LY
+Nh
+Uj
+TV
+TV
+WY
+PH
 aN
 aN
 aN
@@ -47436,18 +51213,18 @@ at
 bl
 bl
 bl
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+NE
+Nh
+Nh
+SS
+Nh
+Nh
+Nh
+TV
+TV
+UZ
+WY
+PH
 aN
 aN
 aN
@@ -47693,18 +51470,18 @@ at
 at
 at
 at
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+XA
+Nx
+Nx
+Nx
+LY
+LY
+Er
+Jg
+PM
+Nx
+Nx
+JR
 aN
 aN
 aN
@@ -49310,56 +53087,56 @@ aN
 aN
 aN
 aN
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -49567,56 +53344,56 @@ aN
 aN
 aN
 aN
-nj
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ip
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-nj
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
+aN
 aN
 aN
 aN
@@ -49818,63 +53595,63 @@ ih
 ih
 ih
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ae
-ab
-ab
-ac
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 nj
-aN
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
 aN
 aN
 aN
@@ -50075,12 +53852,6 @@ gL
 gD
 ih
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -50102,7 +53873,11 @@ ab
 ab
 ab
 ab
-ae
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -50111,13 +53886,16 @@ ab
 ae
 ab
 ab
-ac
-ab
-ab
-ac
+ad
 ab
 ab
 ab
+ab
+ab
+ad
+ab
+ab
+CD
 ae
 ab
 ab
@@ -50131,7 +53909,6 @@ ab
 ab
 ab
 nj
-aN
 aN
 aN
 aN
@@ -50332,12 +54109,6 @@ gC
 gU
 ih
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -50360,10 +54131,15 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
 ae
 ab
 ab
-ae
 ab
 ab
 ab
@@ -50379,16 +54155,17 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Yq
+mH
+mH
+mH
+mH
+mH
+mH
+mH
+CL
 ab
 nj
-aN
 aN
 aN
 aN
@@ -50589,12 +54366,6 @@ gE
 mb
 ih
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -50620,7 +54391,14 @@ ab
 ab
 ab
 ab
-ac
+ab
+ab
+ab
+ab
+ae
+ab
+ab
+ae
 ab
 ab
 ab
@@ -50628,24 +54406,23 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Yq
+mH
+mH
+mH
+mH
+mH
+Gr
+Cq
+Qr
+Nn
+KC
+Qr
+Mk
+Kx
+Uk
 ab
 nj
-aN
 aN
 aN
 aN
@@ -50846,17 +54623,11 @@ fo
 gl
 ih
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
-ac
-ac
+ad
+ad
 ab
 ab
 ab
@@ -50873,18 +54644,6 @@ ab
 ab
 ab
 ab
-ac
-ab
-ae
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ae
 ab
 ab
 ab
@@ -50896,13 +54655,31 @@ ab
 ab
 ab
 ab
+ad
 ab
 ab
 ab
 ab
+ab
+ab
+ab
+Gr
+LH
+LH
+VH
+LH
+LH
+Gr
+Cq
+Qr
+Qr
+Qr
+Qr
+YN
+Kx
+Kw
 ab
 nj
-aN
 aN
 aN
 aN
@@ -51103,12 +54880,6 @@ fo
 gV
 ih
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -51130,10 +54901,18 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ad
+ab
 ae
 ab
 ab
-ae
 ab
 ab
 ab
@@ -51141,25 +54920,23 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Gr
+Qr
+Qr
+Qr
+Qr
+Qr
+Gr
+Un
+Qr
+Qr
+Mj
+CP
+Qr
+Kx
+Rp
 ab
 nj
-aN
 aN
 aN
 aN
@@ -51360,12 +55137,6 @@ fo
 gu
 ih
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -51391,32 +55162,38 @@ ab
 ab
 ab
 ab
-ag
 ab
 ab
 ab
+ae
 ab
 ab
+Zv
+ab
+Lf
+mH
+mH
+mH
+CL
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Gr
+Qr
+Md
+Qr
+Qr
+Qr
+Gr
+Wi
+Md
+Qr
+Eg
+mH
+mH
+mH
+VS
 ab
 nj
-aN
 aN
 aN
 aN
@@ -51617,15 +55394,9 @@ gN
 gW
 ih
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
-ac
+ad
 ab
 ae
 ab
@@ -51641,39 +55412,45 @@ ab
 ab
 ab
 ab
-hj
-hj
-hq
+ab
+ab
+ab
+ab
+ab
+ab
+iO
+iO
+iO
+ab
+ab
+ab
+ab
+iO
+is
+Gr
+PA
+Vm
+Jy
+Gr
+ab
+ab
+Gr
+Fk
+Qw
+Qs
+Qr
+Qr
+Gr
+TX
+Qr
+Qr
+LR
+Gr
+ab
+ab
+ab
+ab
 nj
-nj
-nj
-nj
-ag
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-nj
-aN
 aN
 aN
 aN
@@ -51874,12 +55651,6 @@ gM
 lu
 ih
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -51898,39 +55669,45 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ae
+ab
+ad
+ab
+Zv
+is
+CU
+Qr
+Qr
+Zy
+Gr
+mH
+mH
+mH
+mH
+mH
+mH
+qi
+Vo
+Gr
+mH
+Mh
+Uh
+mH
+mH
+mH
+CL
+ab
+ab
 nj
-ho
-hr
-nj
-hB
-hn
-hu
-ag
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-nj
-aN
 aN
 aN
 aN
@@ -52131,12 +55908,6 @@ gN
 gX
 ih
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -52155,14 +55926,6 @@ ab
 ab
 ab
 ab
-hl
-hn
-hn
-hl
-hn
-hn
-hz
-ag
 ab
 ab
 ab
@@ -52173,21 +55936,35 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+ho
+ho
+ho
+cK
+is
+Im
+QG
+Qr
+Qr
+Gr
+Kj
+KV
+KV
+KV
+KV
+JG
+Qr
+Qr
+Wu
+Qi
+Qr
+Qr
+Yz
+Qr
+Kx
+Uk
 ab
 ab
 nj
-aN
 aN
 aN
 aN
@@ -52388,12 +56165,6 @@ gM
 dd
 ih
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -52412,39 +56183,45 @@ ab
 ab
 ab
 ab
-nj
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ho
-hr
+ho
+hM
 nj
-hn
-hn
-hz
+nj
+nj
 hE
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+CF
+Im
+oP
+Cr
+Qr
+RT
+Qr
+Qr
+Qr
+Qr
+Qr
+Qr
+Qr
+Qr
+Qr
+Qr
+Qr
+Qr
+RN
+SD
+Kx
+Kw
 ab
 ab
 nj
-aN
 aN
 aN
 aN
@@ -52645,12 +56422,6 @@ ih
 ih
 ih
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -52669,39 +56440,45 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 nj
-ho
-hr
-nj
-hn
-hn
+Do
 hz
-hE
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+nj
+UT
+hn
+Fe
+CF
+Im
+UD
+Qr
+SK
+Gr
+PX
+Nb
+Nb
+Nb
+Nb
+Dr
+No
+Qr
+Qr
+Qr
+Qr
+Qr
+Yz
+Qr
+Kx
+Rp
 ab
 ab
 nj
-aN
 aN
 aN
 aN
@@ -52902,12 +56679,6 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -52925,40 +56696,46 @@ ab
 ab
 ab
 ab
-hb
-hl
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+OM
 hn
 hn
-hl
+OM
 hn
 hn
-hz
-hE
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+TR
+CF
+Mu
+Sb
+Qr
+Qr
+Gr
+mH
+mH
+Ox
+mH
+mH
+Lr
+ZY
+RR
+Gr
+mH
+YT
+QM
+mH
+mH
+mH
+VS
 ab
 ab
 nj
-aN
 aN
 aN
 aN
@@ -53159,12 +56936,6 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -53183,39 +56954,45 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 nj
-ho
-hr
-nj
-hB
-hn
+Do
 hz
-hE
-ab
-ab
-ab
-ab
-ab
+nj
+hn
+hn
+TR
+CF
+Gr
+Sb
+Dr
+LT
 fF
-iK
-iR
+ab
+TC
 pF
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+WD
+Gr
+Gy
+Vg
+ES
+Gr
+Cj
+Qr
+Qr
+Up
+Gr
 ab
 ab
 ab
 ab
 nj
-aN
 aN
 aN
 aN
@@ -53416,16 +57193,10 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
-ac
+ad
 ab
 ab
 ab
@@ -53440,39 +57211,45 @@ ab
 ab
 ab
 ab
-hm
-hm
-hs
-hu
+ab
+ab
+ab
+ab
+ab
+ab
+Zd
+UX
+CR
+hn
+OM
 hn
 hn
-hz
 hI
+CF
+QC
+mH
+mH
+mH
+oI
 ab
-ab
-ab
-ab
-ab
-ag
-hz
-pz
+pA
 iZ
 Cd
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+In
+Gy
+Vg
+ES
+Gr
+Yp
+Md
+Qr
+mF
+mH
+mH
+mH
+CL
 ab
 nj
-aN
 aN
 aN
 aN
@@ -53673,12 +57450,6 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -53699,37 +57470,43 @@ ab
 ab
 ab
 ab
-ag
+ab
+ab
+ab
+ab
+ab
+nj
+Xp
 hz
+nj
+UT
 hn
-hn
-hz
 hI
-ac
-ae
+CF
 ab
 ab
 ab
-ag
-hz
+ab
+iO
+ab
 pA
 jd
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+iW
+YY
+Gy
+VG
+JU
+Gr
+Yy
+Qr
+Qr
+Qr
+Qr
+YL
+Kx
+Uk
 ab
 nj
-aN
 aN
 aN
 aN
@@ -53930,12 +57707,6 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -53956,37 +57727,43 @@ ab
 ab
 ab
 ab
-ag
-hz
+ab
+ab
+ab
+ab
+ab
+ac
+hs
+ip
+oO
 hn
 hn
-hz
 hI
-ab
-ab
-ab
-ae
-ab
-ag
-hz
-pz
-hz
+CF
 ab
 ab
 ab
 ab
+iO
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+pA
+iZ
+pA
+Tz
+mH
+mH
+mH
+Gr
+FE
+Md
+Qr
+Qr
+Qr
+Ur
+Kx
+Kw
 ab
 nj
-aN
 aN
 aN
 aN
@@ -54187,17 +57964,11 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
 ab
-ac
+ad
 ab
 ab
 ab
@@ -54213,37 +57984,43 @@ ab
 ab
 ab
 ab
-ag
-hz
-hB
+ab
+ab
+ab
+ab
+ab
+ab
+iO
+is
+pA
 hn
-hz
+hn
 hI
+CF
 ab
 ab
 ab
 ab
+iO
 ab
-ag
-hz
-pz
-hz
-ab
-ac
+pA
+iZ
+pA
 ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+Gr
+UE
+Ib
+DN
+Qr
+Qr
+JI
+Kx
+Rp
 ab
 nj
-aN
 aN
 aN
 aN
@@ -54444,47 +58221,9 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
-ac
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-hj
-hj
-hq
-hy
-hn
-hn
-hz
-hI
-ae
-ab
-ab
 ad
 ab
-fV
-hz
-pz
-hz
 ab
 ab
 ab
@@ -54498,9 +58237,47 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+iO
+cK
+cK
+hM
+Lq
+hn
+hn
+hI
+CF
+ab
+ab
+ab
+ab
+iO
+ab
+pA
+iZ
+pA
+ab
+ab
+ab
+ab
+Tz
+mH
+mH
+mH
+mH
+mH
+mH
+mH
+VS
 ab
 nj
-aN
 aN
 aN
 aN
@@ -54701,12 +58478,6 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -54725,23 +58496,30 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 nj
-ho
-hr
-nj
-hn
-hn
+Do
 hz
+nj
+UT
+hn
 hI
+CF
 ab
-ac
-hj
-hj
+Ja
 cK
-hq
-hy
-pz
-hy
+cK
+iO
+ab
+Lq
+iZ
+Lq
 ab
 ab
 ab
@@ -54750,14 +58528,13 @@ ab
 ab
 ab
 ab
-ad
+Jo
 ab
 ab
 ab
 ab
 ab
 nj
-aN
 aN
 aN
 aN
@@ -54958,12 +58735,6 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -54982,22 +58753,29 @@ ab
 ab
 ab
 ab
-hl
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+OM
 hn
 hn
-hl
+OM
 hn
 hn
-hz
 hI
-ab
-hq
+CF
+iO
+hM
 nj
 nj
 nj
 nj
 nj
-iU
+YW
 nj
 nj
 nj
@@ -55014,7 +58792,6 @@ ab
 ab
 ab
 nj
-aN
 aN
 aN
 aN
@@ -55215,12 +58992,6 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -55239,25 +59010,32 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 nj
-ho
-hr
+Do
+hz
 nj
-hB
 hn
-hy
+hn
 hI
-ag
+Qe
+is
 nj
 nj
-ii
 iq
 iB
 iL
+jo
 hn
-jg
 jm
 ez
+Ra
 nj
 nj
 ab
@@ -55271,7 +59049,6 @@ ab
 ae
 ab
 nj
-aN
 aN
 aN
 aN
@@ -55472,12 +59249,6 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -55496,31 +59267,38 @@ ab
 ab
 ab
 ab
-hl
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+OM
 hn
 hn
-hl
+OM
 hn
 hn
-nj
 hI
-ag
+Qe
+is
 nj
-hQ
+YK
 hn
 hn
 en
 en
-iY
 jf
-jk
+jn
 ey
-fd
-nj
-hI
-ac
+fh
+Rw
+ir
+CF
 ad
-hj
+TH
+ho
 ab
 ab
 ab
@@ -55528,7 +59306,6 @@ ab
 ab
 ab
 nj
-aN
 aN
 aN
 aN
@@ -55729,12 +59506,6 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -55753,30 +59524,37 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 nj
-ho
-hr
+Do
+hz
 nj
+UT
 hn
-hn
-nj
 hK
-hq
+WF
 hM
 ie
+Zk
 hn
 en
-iD
 iN
+Zl
 hn
-jf
 jn
 fa
 fi
-nj
-hI
+YR
+ir
 ab
-iH
+iO
+hO
 nj
 nj
 nj
@@ -55785,7 +59563,6 @@ nj
 nj
 nj
 nj
-aN
 aN
 aN
 aN
@@ -55986,33 +59763,34 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
+ad
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ac
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ac
-ag
+hs
+KH
 nj
 hn
 hn
@@ -56020,22 +59798,21 @@ nj
 nj
 nj
 nj
-hX
+NS
 hn
 en
-iC
 iM
+Qx
 hn
-jf
-jk
+jn
 ey
 fh
-nj
+Xh
 ir
-ab
+Jo
 iO
+ad
 nj
-aN
 aN
 aN
 aN
@@ -56243,12 +60020,6 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -56270,29 +60041,35 @@ ab
 ab
 ab
 ab
-nj
-hn
-hn
-hD
-hn
-hn
-Bn
-hn
-hn
+ab
+ab
+ab
+ab
+ab
+ab
 is
+nj
+hn
+hn
+Cm
+hn
+hn
+TK
+hn
+hn
+Qm
 en
 en
 hn
-iL
 jo
 jM
 jO
+JB
+ir
+WF
+cK
+hM
 nj
-hK
-hj
-hq
-nj
-aN
 aN
 aN
 aN
@@ -56500,12 +60277,6 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -56527,6 +60298,13 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ad
+is
 nj
 hn
 hn
@@ -56535,7 +60313,7 @@ nj
 nj
 nj
 nj
-ij
+Ww
 hn
 hn
 hn
@@ -56546,10 +60324,9 @@ hn
 nj
 nj
 nj
-hM
+ie
 nj
 nj
-aN
 aN
 aN
 aN
@@ -56757,12 +60534,6 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
@@ -56784,6 +60555,13 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 nj
 hn
 hn
@@ -56792,7 +60570,7 @@ aN
 aN
 aN
 nj
-il
+XG
 hn
 hn
 hn
@@ -56800,13 +60578,12 @@ hn
 hn
 hn
 hn
-kb
 kj
 ks
+FC
 kq
-kJ
+GD
 nj
-aN
 aN
 aN
 aN
@@ -57014,17 +60791,18 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
 ab
-ac
+ad
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -57049,21 +60827,20 @@ aN
 aN
 aN
 nj
-ik
+Kn
 hn
-eq
-iL
-ex
-hn
-hn
+GG
+jo
+IO
 hn
 hn
-kj
+hn
+hn
+ks
 kq
 kq
-kJ
+GD
 nj
-aN
 aN
 aN
 aN
@@ -57271,17 +61048,18 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
 ab
 ab
 ab
 ae
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -57307,20 +61085,19 @@ aN
 aN
 nj
 nj
-iz
+OK
 nj
 nj
 nj
-jd
 iW
-jd
+VT
+iW
 nj
-BQ
+Ky
 kq
 kq
-kJ
+GD
 nj
-aN
 aN
 aN
 aN
@@ -57528,13 +61305,14 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
 nj
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -57563,21 +61341,20 @@ aN
 aN
 aN
 nj
-im
+MM
 iy
 iy
 nj
 nj
-hz
-iV
-hz
+pA
+JM
+pA
 nj
-qF
+Rg
 kq
 kq
-kJ
+GD
 nj
-aN
 aN
 aN
 aN
@@ -57784,17 +61561,11 @@ aN
 aN
 aN
 aN
-nj
-nj
-nj
-nj
-nj
-nj
-nj
+aN
 nj
 ab
 ab
-ac
+ad
 ab
 ab
 ab
@@ -57809,7 +61580,14 @@ ab
 ab
 ab
 ab
-ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ad
 ab
 ab
 nj
@@ -57820,21 +61598,20 @@ aN
 aN
 aN
 nj
-io
+EH
 iy
-iF
+PD
 nj
 nj
-hz
-iV
-hz
+pA
+JM
+pA
 nj
-qG
+YO
 kq
 kq
-kJ
+GD
 nj
-aN
 aN
 aN
 aN
@@ -58041,6 +61818,7 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 ab
@@ -58077,21 +61855,20 @@ aN
 aN
 aN
 nj
-in
 iA
+Ug
 nj
 nj
 nj
-hz
-iX
-hz
+pA
+EL
+pA
 nj
-kl
+DF
 kq
-kC
 kL
+Ku
 nj
-aN
 aN
 aN
 aN
@@ -58298,28 +62075,29 @@ aN
 aN
 aN
 aN
+aN
 nj
+iO
+eh
+it
+it
+it
+it
+it
+it
+it
+it
+it
+it
+gB
+nF
 ab
-ef
-it
-it
-it
-it
-it
-it
-it
-it
-it
-it
-it
-ge
-ab
 nj
 nj
 nj
-eU
 iR
-hr
+pF
+hz
 nj
 nj
 nj
@@ -58339,16 +62117,15 @@ nj
 nj
 nj
 nj
-hz
-iV
-hz
+pA
+JM
+pA
 nj
 nj
 nj
 nj
 nj
 nj
-aN
 aN
 aN
 aN
@@ -58555,34 +62332,35 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 it
 eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+eV
+jG
+kC
 it
-hM
+ie
 nj
-kn
 kT
+Bz
 mt
 mt
 mt
-nt
+BN
 mt
-AY
 Bd
 gY
 gI
+Sh
 nj
 kr
 kr
@@ -58593,17 +62371,16 @@ aN
 aN
 aN
 nj
-iJ
+tw
 gj
 gj
-hz
-iV
-hz
+pA
+JM
+pA
 gj
 gj
-jz
+Nc
 nj
-aN
 aN
 aN
 aN
@@ -58812,24 +62589,25 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 it
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
+eq
+hg
+hu
+hQ
+il
+io
+io
+iD
+jg
+kb
+jG
 it
 kr
 nj
-kp
+qG
 kr
 kr
 kr
@@ -58839,7 +62617,7 @@ kr
 kr
 kr
 kr
-mv
+nP
 nj
 kr
 kr
@@ -58851,16 +62629,15 @@ aN
 aN
 nj
 gj
-gi
-iI
-hz
-iW
-hz
 iI
 jv
+pA
+VT
+pA
+jv
+Yb
 gj
 nj
-aN
 aN
 aN
 aN
@@ -59069,23 +62846,24 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 it
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
+eT
+hg
+hA
+hX
+hu
+hu
+hu
+hu
+hu
+hu
+kJ
 it
 kr
-hA
+ob
 kr
 kr
 kr
@@ -59097,7 +62875,7 @@ kr
 kr
 kr
 kr
-BM
+De
 kr
 kr
 nj
@@ -59107,17 +62885,16 @@ aN
 aN
 aN
 nj
-gi
-iu
-hi
-iv
-iP
-iv
-ht
-ju
-jv
+iI
+VN
+UY
+KY
+OH
+hP
+jJ
+HC
+Yb
 nj
-aN
 aN
 aN
 aN
@@ -59326,34 +63103,35 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 it
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
+eU
+hg
+hu
+ii
+im
+im
+im
+hu
+jg
+kk
+jG
 it
-mv
+nP
 nj
-kK
+zL
 kr
 kr
 nq
-ob
+BE
 kr
 kr
 kr
 kr
 kr
-mv
+nP
 nj
 kr
 kr
@@ -59364,17 +63142,16 @@ aN
 aN
 aN
 nj
-gx
-hi
-iv
-KX
+hk
+UY
+KY
+Hm
 iS
-KX
-iv
-ht
+Hm
+hP
 jJ
+IJ
 nj
-aN
 aN
 aN
 aN
@@ -59583,34 +63360,35 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 it
-eA
-eA
-eA
-eA
-eA
-eA
-eA
+eZ
 eV
-eA
-eA
-eA
+eV
+eV
+eV
+eV
+eV
+iF
+eV
+jG
+kK
 it
 kr
 nj
-hO
+AY
 kr
 kr
-gb
 ai
 lg
+BO
 kr
-AZ
 Be
 Bh
 Bm
+CE
 nj
 kr
 kr
@@ -59621,17 +63399,16 @@ aN
 aN
 aN
 nj
-gx
 iv
-KX
+KY
+Hm
 iS
-jt
+Tq
 iS
-KX
-iv
-jJ
+Hm
+KY
+IJ
 nj
-aN
 aN
 aN
 aN
@@ -59840,36 +63617,37 @@ aN
 aN
 aN
 aN
+aN
 nj
-ab
-eg
-it
-it
-it
-it
-it
-it
-it
+iO
 ej
 it
 it
 it
-gh
+it
+it
+it
+it
+iJ
+it
+it
+gB
+nI
 kr
 nj
 nj
-oA
 AX
 oA
+AX
 nj
 nj
-BD
+BS
 nj
 nj
 nj
 nj
 nj
-gg
+gb
 kr
 nj
 aN
@@ -59878,17 +63656,16 @@ aN
 aN
 aN
 nj
-hg
 iP
+OH
 iS
-KR
 jj
 KW
+IM
 iS
-km
 jK
+Ok
 nj
-aN
 aN
 aN
 aN
@@ -60097,34 +63874,35 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 ab
 ab
 ab
 ab
-ab
-hm
+iO
 hs
+ip
 nj
-hN
 ji
+jh
 kr
-ga
+nr
 kr
 kr
 nj
-nF
 oz
+BA
 kr
-Br
 By
+BF
 nj
-gg
+gb
 kr
-BT
 BV
 BX
+Vi
 nj
 kr
 kr
@@ -60135,17 +63913,16 @@ aN
 aN
 aN
 nj
-gx
 iv
 KY
+Jr
 iS
-jw
+Qb
 iS
+Jr
 KY
-iv
-jJ
+IJ
 nj
-aN
 aN
 aN
 aN
@@ -60354,6 +64131,7 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 ab
@@ -60361,27 +64139,27 @@ ab
 ab
 ab
 ae
-ab
-ag
+iO
+is
 nj
-jh
+ns
 kr
 kr
-ai
+lg
 kr
 kr
 nj
-nI
+AZ
 kr
 kr
 kr
-Bz
+BG
 nj
-BS
 BZ
 BU
 BW
 BY
+Fx
 nj
 kr
 kr
@@ -60392,17 +64170,16 @@ aN
 aN
 aN
 nj
-gx
 hk
-iv
+Nj
 KY
+Jr
 iS
 iS
-iv
 hP
-jJ
+jx
+IJ
 nj
-aN
 aN
 aN
 aN
@@ -60611,6 +64388,7 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 ab
@@ -60621,18 +64399,18 @@ ab
 ab
 ab
 nj
-eU
 iR
-hr
+pF
+hz
 nj
 nj
-jC
+nS
 nj
-gg
+gb
 kr
 kr
 kr
-mv
+nP
 nj
 nj
 nj
@@ -60649,17 +64427,16 @@ aN
 aN
 aN
 nj
-hx
 iG
-hk
-iv
-iP
-iv
+HL
+Nj
+KY
+OH
 hP
 jx
 jy
+jz
 nj
-aN
 aN
 aN
 aN
@@ -60868,32 +64645,33 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 ab
 ab
-ac
+ad
 ab
 ab
 ab
 ab
 ab
 ab
-ab
-hs
+iO
+ip
 nj
-nW
 Ca
 nB
+qF
 kr
 kr
-Bo
 Bu
+BB
 kr
 nj
-zL
+Bn
 kr
-ga
+nr
 kr
 kr
 kr
@@ -60906,17 +64684,16 @@ aN
 aN
 aN
 nj
-hG
 hx
+iG
 iT
 iT
 iT
 iT
 iT
-jy
 jz
+Nc
 nj
-aN
 aN
 aN
 aN
@@ -61125,6 +64902,7 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 ab
@@ -61139,15 +64917,15 @@ ab
 ae
 ab
 nj
-eT
+nL
 kr
-nx
+zN
 kr
 kr
-Bg
 Bt
+BC
 kr
-nx
+zN
 kr
 kr
 kr
@@ -61173,7 +64951,6 @@ nj
 nj
 nj
 nj
-aN
 aN
 aN
 aN
@@ -61382,39 +65159,39 @@ aN
 aN
 aN
 aN
-nj
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-hq
-nj
-BO
-Cb
-nB
-kr
-kr
-Bp
-Bv
-kr
-nj
-zL
-kr
-gb
-kr
-kr
-kr
-kr
-kr
-nj
 aN
+nj
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+iO
+hM
+nj
+Cb
+nW
+qF
+kr
+kr
+Bv
+BD
+kr
+nj
+Bn
+kr
+ai
+kr
+kr
+kr
+kr
+kr
+nj
 aN
 aN
 aN
@@ -61639,39 +65416,39 @@ aN
 aN
 aN
 aN
-nj
-ab
-ab
-ab
-ab
-ab
-ac
-ab
-ab
-nj
-eU
-iR
-hr
-nj
-nj
-kk
-nj
-gg
-kr
-kr
-kr
-mv
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-kr
-kr
-nj
 aN
+nj
+ab
+ab
+ab
+ab
+ab
+ad
+ab
+ab
+nj
+iR
+pF
+hz
+nj
+nj
+nY
+nj
+gb
+kr
+kr
+kr
+nP
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+kr
+kr
+nj
 aN
 aN
 aN
@@ -61896,39 +65673,39 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 ab
 ab
-ac
+ad
 ab
 ab
-ab
-ag
+iO
+is
 nj
-hN
+ji
 kr
 kr
-nr
+mv
 kr
 kr
 nj
-nM
+Ba
 kr
 kr
 kr
-BB
+BL
 nj
-BE
 BH
 BI
 BJ
 BK
+CZ
 nj
 kr
 kr
 nj
-aN
 aN
 aN
 aN
@@ -62153,39 +65930,39 @@ aN
 aN
 aN
 aN
-nj
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-hq
-nj
-jh
-ns
-kr
-gb
-kr
-kr
-nj
-nL
-oz
-kr
-kr
-BA
-nj
-gg
-gb
-kr
-kr
-kr
-nj
-kr
-kr
-nj
 aN
+nj
+ab
+ab
+ab
+ab
+ab
+ab
+iO
+hM
+nj
+ns
+jt
+kr
+ai
+kr
+kr
+nj
+Bg
+BA
+kr
+kr
+BM
+nj
+gb
+ai
+kr
+kr
+kr
+nj
+kr
+kr
+nj
 aN
 aN
 aN
@@ -62410,9 +66187,10 @@ aN
 aN
 aN
 aN
+aN
 nj
-ab
-ef
+iO
+eh
 it
 it
 it
@@ -62420,29 +66198,28 @@ it
 it
 it
 it
-eZ
+iK
 it
 it
-it
-gm
+gB
+nM
 kr
 nj
 nj
-zN
 nx
 zN
+nx
 nj
 nj
-BF
+BT
 nj
 nj
 nj
 nj
 nj
-gg
+gb
 kr
 nj
-aN
 aN
 aN
 aN
@@ -62667,39 +66444,39 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 it
-eA
-eA
-eA
-eA
-eA
-eA
-eA
+ga
 fc
-eA
-eA
-eA
+fc
+fc
+fc
+fc
+fc
+iU
+fc
+kl
+nt
 it
 kr
 nj
-zL
+Bn
 kr
 kr
-ga
 nr
+mv
 kr
 kr
-Ba
-Bd
+pr
 gY
 gI
+Sh
 nj
 kr
 kr
 nj
-aN
 aN
 aN
 aN
@@ -62924,24 +66701,25 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 it
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-it
-mv
-nj
 gg
+hl
+hD
+ij
+in
+in
+iz
+iY
+jw
+km
+kl
+it
+nP
+nj
+gb
 kr
 kr
 kr
@@ -62951,12 +66729,11 @@ Bx
 kr
 kr
 kr
-mv
+nP
 nj
 kr
 kr
 nj
-aN
 aN
 aN
 aN
@@ -63181,39 +66958,39 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 it
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
+gi
+hl
+hG
+hG
+hG
+hG
+hG
+hG
+hG
+kn
+nv
 it
 kr
-hA
+ob
 kr
 kr
 kr
 kr
-Bw
 js
 Bw
+js
 kr
 kr
 kr
 kr
-BN
+Cv
 kr
 kr
 nj
-aN
 aN
 aN
 aN
@@ -63438,24 +67215,25 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 it
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
+gx
+hl
+hN
+ik
+ik
+ik
+iC
+iY
+jC
+km
+kp
 it
 kr
 nj
-gg
+gb
 kr
 kr
 kr
@@ -63465,12 +67243,11 @@ Bx
 kr
 kr
 kr
-jG
+QL
 nj
 kr
 kr
 nj
-aN
 aN
 aN
 aN
@@ -63695,39 +67472,39 @@ aN
 aN
 aN
 aN
+aN
 nj
 ab
 it
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
-eA
+hb
+fc
+fc
+fc
+fc
+fc
+fc
+fc
+fc
+kp
+nt
 it
-hM
+ie
 nj
 ix
 ix
+jD
 iE
-jq
-iE
+jD
 kr
-iE
-jq
+jD
 iE
 jD
 jF
+Wo
 nj
 kr
 kr
 nj
-aN
 aN
 aN
 aN
@@ -63952,10 +67729,10 @@ aN
 aN
 aN
 aN
+aN
 nj
-ab
-eg
-it
+iO
+ej
 it
 it
 it
@@ -63967,6 +67744,7 @@ it
 it
 it
 gB
+nI
 ab
 nj
 nj
@@ -63974,7 +67752,7 @@ nj
 nj
 nj
 nj
-BC
+BQ
 nj
 nj
 nj
@@ -63984,7 +67762,6 @@ nj
 kr
 kr
 nj
-aN
 aN
 aN
 aN
@@ -64209,39 +67986,39 @@ aN
 aN
 aN
 aN
-nj
-ab
-ab
-ab
-ac
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ac
-ab
-nj
-nv
-kr
-kr
-ga
-kr
-kr
-kr
-ga
-kr
-kr
-BL
-nj
-kr
-kr
-nj
 aN
+nj
+ab
+ab
+ab
+ad
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ad
+ab
+nj
+Bo
+kr
+kr
+nr
+kr
+kr
+kr
+nr
+kr
+kr
+SV
+nj
+kr
+kr
+nj
 aN
 aN
 aN
@@ -64466,39 +68243,39 @@ aN
 aN
 aN
 aN
-nj
-ab
-ab
-ab
-ab
-eh
-ab
-ab
-ab
-ac
-ab
-ab
-ab
-ab
-eh
-ab
-nj
-nS
-kr
-nS
-kr
-nS
-kr
-BG
-kr
-BG
-kr
-BG
-nj
-kr
-kr
-nj
 aN
+nj
+ab
+ab
+ab
+ab
+hO
+ab
+ab
+ab
+ad
+ab
+ab
+ab
+ab
+hO
+ab
+nj
+Bp
+kr
+Bp
+kr
+Bp
+kr
+KR
+kr
+KR
+kr
+KR
+nj
+Ej
+nP
+nj
 aN
 aN
 aN
@@ -64723,39 +68500,39 @@ aN
 aN
 aN
 aN
-nj
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ac
-ab
-ab
-nj
-nP
-kr
-nP
-kr
-nP
-kr
-nP
-kr
-nP
-kr
-nP
-nj
-kr
-kr
-nj
 aN
+nj
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ad
+ab
+ab
+nj
+Br
+kr
+Br
+kr
+Br
+kr
+Br
+kr
+Br
+kr
+Br
+nj
+Dg
+Dg
+nj
 aN
 aN
 aN
@@ -64980,39 +68757,39 @@ aN
 aN
 aN
 aN
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
-nj
 aN
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+nj
+kr
+kr
+nj
 aN
 aN
 aN
@@ -65266,10 +69043,10 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
+nj
+Zp
+nP
+nj
 aN
 aN
 aN
@@ -65521,17 +69298,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+Fz
+Fz
+Lt
+Lt
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
 aN
 aN
 aN
@@ -65778,17 +69555,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+ZS
+Gl
+ZS
+ZS
+Pd
+Fz
+EU
+Dq
+PC
+Fz
 aN
 aN
 aN
@@ -66035,17 +69812,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+ZS
+ZS
+ZS
+ZS
+ZS
+Fz
+ZS
+Zu
+ZS
+Fz
 aN
 aN
 aN
@@ -66292,17 +70069,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+Si
+DG
+Si
+Si
+ZS
+Oa
+ZS
+ZS
+tA
+Fz
 aN
 aN
 aN
@@ -66549,17 +70326,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+IZ
+ZS
+KP
+Si
+ZS
+Fz
+Jl
+ZS
+Zu
+Fz
 aN
 aN
 aN
@@ -66806,17 +70583,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+WA
+ZS
+OZ
+PK
+ZS
+Fz
+rt
+FI
+GV
+Fz
 aN
 aN
 aN
@@ -67063,17 +70840,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+Fz
+Fz
+Fz
+Fz
+tv
+Fz
+Fz
+Fz
+Fz
+Fz
 aN
 aN
 aN
@@ -67320,17 +71097,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+GV
+Sw
+Lp
+ZS
+ZS
+ZS
+Lp
+Sw
+GV
+Fz
 aN
 aN
 aN
@@ -67577,17 +71354,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+Tj
+Zu
+Vu
+ZS
+ZS
+ZS
+Vu
+ZS
+Tj
+Fz
 aN
 aN
 aN
@@ -67834,17 +71611,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+Fz
+XN
+PG
+Ho
+ZS
+Jc
+RM
+NN
+Fz
+Fz
 aN
 aN
 aN
@@ -68091,17 +71868,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+GV
+Sw
+Lp
+ZS
+ZS
+ZS
+Lp
+XW
+GV
+Fz
 aN
 aN
 aN
@@ -68348,17 +72125,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+Tj
+ZS
+Vu
+ZS
+ZS
+ZS
+Vu
+ZS
+Tj
+Fz
 aN
 aN
 aN
@@ -68605,17 +72382,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+Fz
+XN
+PG
+Ho
+ZS
+Jc
+RM
+NN
+Fz
+Fz
 aN
 aN
 aN
@@ -68862,17 +72639,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+GV
+Sw
+Lp
+Zu
+ZS
+ZS
+Lp
+Sw
+GV
+Fz
 aN
 aN
 aN
@@ -69119,17 +72896,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+Tj
+ZS
+GQ
+ZS
+WH
+ZS
+GQ
+ZS
+Tj
+Fz
 aN
 aN
 aN
@@ -69376,17 +73153,17 @@ aN
 aN
 aN
 aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
-aN
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
 aN
 aN
 aN


### PR DESCRIPTION
## What Does This PR Do
Restores ERT and other shuttles to the CentComm level of EmeraldStation (z2.dmm).
Follow up for #348
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If the station needs to call an ERT, they'll have a shuttle to take to the station!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![z2 dmm 1 diff](https://user-images.githubusercontent.com/1283521/108583693-03274980-7301-11eb-87a4-262040296ebb.png)
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
fix: Fixed shuttles on CentComm level for EmeraldStation; ERT has a shuttle again
/:cl:
