### PR TITLE
Voting for Nextmap when Emergency Shuttle docks

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -10,7 +10,7 @@ SUBSYSTEM_DEF(ticker)
 	/// Time the world started, relative to world.time
 	var/round_start_time = 0
 	/// Default timeout for if world.Reboot() doesnt have a time specified
-	var/const/restart_timeout = 2 MINUTES
+	var/const/restart_timeout = 1 MINUTES
 	/// Current status of the game. See code\__DEFINES\game.dm
 	var/current_state = GAME_STATE_STARTUP
 	/// Do we want to force-start as soon as we can
@@ -545,9 +545,6 @@ SUBSYSTEM_DEF(ticker)
 
 	//Ask the event manager to print round end information
 	SSevents.RoundEnd()
-
-	// ask the players which map they want to play on next
-	INVOKE_ASYNC(SSvote, /datum/controller/subsystem/vote/.proc/initiate_vote, VOTE_TYPE_MAP)
 
 	//make big obvious note in game logs that round ended
 	log_game("///////////////////////////////////////////////////////")

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -231,6 +231,8 @@
 				mode = SHUTTLE_DOCKED
 				timer = world.time
 				emergency_shuttle_docked.Announce("The Emergency Shuttle has docked with the station. You have [timeLeft(600)] minutes to board the Emergency Shuttle.")
+				// ask the players which map they want to play on next
+				INVOKE_ASYNC(SSvote, /datum/controller/subsystem/vote/.proc/initiate_vote, VOTE_TYPE_MAP)
 
 /*
 				//Gangs only have one attempt left if the shuttle has docked with the station to prevent suffering from dominator delays


### PR DESCRIPTION
## What Does This PR Do
Changes when the vote for the map for next round occurs.

Currently, it is supposed to happen at round end; when the end of round shenanigans happen.
However, due to a race condition with the callback, the vote isn't always held.

This PR moves the vote to occur when the Emergency Shuttle docks with the station.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to vote on the next map is important, especially if you don't like the current map!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Voting for the map to be used next round now happens when the emergency shuttle docks with the station.
tweak: End of round shenanigans now last for 60 seconds again.
/:cl:
