### PR TITLE
New Space Ruin: Scenic Hut

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/scenichut.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/scenichut.dmm
@@ -1,0 +1,60 @@
+"a" = (/turf/template_noop,/area/template_noop)
+"b" = (/turf/simulated/floor/plating/asteroid/airless,/area/space)
+"c" = (/turf/simulated/mineral/random/low_chance,/area/space)
+"d" = (/turf/simulated/mineral/random/labormineral,/area/space)
+"e" = (/turf/simulated/mineral/random/high_chance,/area/space)
+"f" = (/turf/simulated/wall,/area/space)
+"g" = (/turf/simulated/floor/plasteel{dir = 5; icon_state = "dark"; tag = "icon-vault (NORTHEAST)"},/area/space)
+"h" = (/obj/structure/closet,/obj/item/clothing/under/rank/psych/turtleneck,/obj/item/clothing/under/tourist_suit,/obj/item/storage/firstaid,/turf/simulated/floor/plasteel{dir = 5; icon_state = "dark"; tag = "icon-vault (NORTHEAST)"},/area/space)
+"i" = (/obj/structure/table,/obj/item/flashlight/lamp,/turf/simulated/floor/plasteel{dir = 5; icon_state = "dark"; tag = "icon-vault (NORTHEAST)"},/area/space)
+"j" = (/obj/structure/grille,/obj/structure/window/full/reinforced,/turf/space,/area/space)
+"k" = (/obj/structure/chair/office/dark{dir = 4},/turf/simulated/floor/plasteel{dir = 5; icon_state = "dark"; tag = "icon-vault (NORTHEAST)"},/area/space)
+"l" = (/obj/structure/table,/obj/item/paper,/obj/item/pen,/turf/simulated/floor/plasteel{dir = 5; icon_state = "dark"; tag = "icon-vault (NORTHEAST)"},/area/space)
+"m" = (/obj/structure/table,/obj/item/paper_bin,/turf/simulated/floor/plasteel{dir = 5; icon_state = "dark"; tag = "icon-vault (NORTHEAST)"},/area/space)
+"n" = (/obj/machinery/door/airlock/hatch,/turf/simulated/floor/plasteel{dir = 5; icon_state = "dark"; tag = "icon-vault (NORTHEAST)"},/area/space)
+"o" = (/obj/machinery/door/airlock/hatch,/turf/simulated/floor/plating/asteroid/airless,/area/space)
+"p" = (/obj/machinery/portable_atmospherics/canister/oxygen,/turf/simulated/floor/plasteel{dir = 5; icon_state = "dark"; tag = "icon-vault (NORTHEAST)"},/area/space)
+"q" = (/obj/item/storage/firstaid/o2,/turf/simulated/floor/plasteel{dir = 5; icon_state = "dark"; tag = "icon-vault (NORTHEAST)"},/area/space)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaabbaaaaaaaaaaa
+aaaaaaaaaaaaaaaabbaaaaaaaabbbbbaaaaaaaaa
+aaaaaaaaaaaaaaabbbbaaaaaabbbbbbbaaaaaaaa
+aaaaaaaaaaaaaabbbbbbaaabbbbbbbbbbaaaaaaa
+aaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbaaaaaa
+aaaaaaaaaaaaabbbbbcccccccbbbbbbbbaaaaaaa
+aaaaaaaaaaaabbbbccccccccccbbbbbbaaaaaaaa
+aaaaaaaaaaabbbbccddddddddddcbbbbaaaaaaaa
+aaaaaaaaaabbbbccdeeeeeeeedcbbbbaaaaaaaaa
+aaaaaaaaabbbbccdeeeeeeeedccfbbbaaaaaaaaa
+aaaaaaaaabbbccdeeeeeeeedccgfbbaaaaaaaaaa
+aaaaaaaaabbccdeeeeeeeedchggfbbaaaaaaaaaa
+aaaaaaaaaabcddddddddddcpggijbaaaaaaaaaaa
+aaaaaaaaaaabccccccccccqggkljaaaaaaaaaaaa
+aaaaaaaaaaaaabccccbfcfggggmjaaaaaaaaaaaa
+aaaaaaaaaaaaaaabcbbfbngggggfaaaaaaaaaaaa
+aaaaaaaaaaaaaaaabbbfofffffffaaabaaaaaaaa
+aaaaabaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaa
+aaaabbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaabdbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaabddbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaabdbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaabbbaaaaaaaaaaaaaaaaaaaaabbaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabbbaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaabbbbaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaabbbaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"}

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -283,3 +283,10 @@
 	suffix = "debris3.dmm"
 	name = "Debris field 3"
 	description = "A bunch of metal chunks, wires and space waste. It used to be an arcade."
+
+/datum/map_template/ruin/space/scenichut
+	id = "scenichut"
+	suffix = "scenichut.dmm"
+	name = "Peculiar Rock"
+	description = "A strange shelter with a beautiful view of space and no clear origin. The stones glitter with rare minerals."
+	cost = 0


### PR DESCRIPTION
## What Does This PR Do
@LectroNyx created a space ruin called Scenic Hut. This PR adds it to the game.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Another space ruin adds variety to off-station content.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Coming Real Soon:tm:
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Adds the new space ruin Scenic Hut
/:cl:
