### PR TITLE
Remove Tasers

### DIFF
--- a/_maps/map_files/emerald/emerald.dmm
+++ b/_maps/map_files/emerald/emerald.dmm
@@ -72687,17 +72687,17 @@
 /obj/structure/rack,
 /obj/effect/decal/warning_stripes/north,
 /obj/structure/window/reinforced,
-/obj/item/gun/energy/gun/advtaser{
+/obj/item/gun/projectile/automatic/pistol/enforcer{
 	layer = 2.91;
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/gun/advtaser{
+/obj/item/gun/projectile/automatic/pistol/enforcer{
 	layer = 2.92;
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/obj/item/gun/energy/gun/advtaser{
+/obj/item/gun/projectile/automatic/pistol/enforcer{
 	layer = 2.93;
 	pixel_x = 3;
 	pixel_y = -3
@@ -79545,17 +79545,17 @@
 	tag = "icon-rwindow (EAST)"
 	},
 /obj/structure/window/reinforced,
-/obj/item/gun/energy/gun/advtaser{
+/obj/item/gun/projectile/automatic/pistol/enforcer{
 	layer = 2.91;
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/gun/advtaser{
+/obj/item/gun/projectile/automatic/pistol/enforcer{
 	layer = 2.92;
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/obj/item/gun/energy/gun/advtaser{
+/obj/item/gun/projectile/automatic/pistol/enforcer{
 	layer = 2.93;
 	pixel_x = 3;
 	pixel_y = -3

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -273,14 +273,6 @@ GLOBAL_LIST_INIT(all_supply_groups, list(SUPPLY_EMERGENCY,SUPPLY_SECURITY,SUPPLY
 	cost = 15
 	containername = "laser crate"
 
-/datum/supply_packs/security/taser
-	name = "Stun Guns Crate"
-	contains = list(/obj/item/gun/energy/gun/advtaser,
-					/obj/item/gun/energy/gun/advtaser,
-					/obj/item/gun/energy/gun/advtaser)
-	cost = 15
-	containername = "stun gun crate"
-
 /datum/supply_packs/security/disabler
 	name = "Disabler Crate"
 	contains = list(/obj/item/gun/energy/disabler,

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -6,7 +6,6 @@
 GLOBAL_LIST_INIT(summoned_guns, list(
 	/obj/item/gun/energy/disabler,
 	/obj/item/gun/energy/gun,
-	/obj/item/gun/energy/gun/advtaser,
 	/obj/item/gun/energy/laser,
 	/obj/item/gun/projectile/revolver,
 	/obj/item/gun/projectile/revolver/detective,

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -85,7 +85,7 @@
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	id = /obj/item/card/id/security
 	l_pocket = /obj/item/flash
-	suit_store = /obj/item/gun/energy/gun/advtaser
+	suit_store = /obj/item/gun/projectile/automatic/pistol/enforcer
 	pda = /obj/item/pda/warden
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 1
@@ -188,7 +188,7 @@
 	l_ear = /obj/item/radio/headset/headset_sec/alt
 	id = /obj/item/card/id/security
 	l_pocket = /obj/item/flash
-	suit_store = /obj/item/gun/energy/gun/advtaser
+	suit_store = /obj/item/gun/projectile/automatic/pistol/enforcer
 	pda = /obj/item/pda/security
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 1
@@ -259,7 +259,7 @@
 	l_ear = /obj/item/radio/headset/headset_sec/alt
 	id = /obj/item/card/id/security
 	l_pocket = /obj/item/flash
-	suit_store = /obj/item/gun/energy/gun/advtaser
+	suit_store = /obj/item/gun/projectile/automatic/pistol/enforcer
 	pda = /obj/item/pda/security
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 1

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -119,9 +119,9 @@
 		if(/obj/item/gun/energy/lasercannon)
 			iconholder = 1
 
-		if(/obj/item/gun/energy/taser)
-			eprojectile = /obj/item/projectile/beam
-			eshot_sound = 'sound/weapons/laser.ogg'
+		// if(/obj/item/gun/energy/taser)
+		// 	eprojectile = /obj/item/projectile/beam
+		// 	eshot_sound = 'sound/weapons/laser.ogg'
 
 		if(/obj/item/gun/energy/gun)
 			eprojectile = /obj/item/projectile/beam	//If it has, going to kill mode

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -158,7 +158,7 @@
 	new /obj/item/storage/box/flashbangs(src)
 	new /obj/item/reagent_containers/spray/pepper(src)
 	new /obj/item/melee/baton/loaded(src)
-	new /obj/item/gun/energy/gun/advtaser(src)
+	new /obj/item/gun/projectile/automatic/pistol/enforcer(src)
 	new /obj/item/storage/belt/security/sec(src)
 	new /obj/item/storage/box/holobadge(src)
 	new /obj/item/clothing/gloves/color/black/krav_maga/sec(src)

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -64,7 +64,7 @@
 				/obj/item/robot_parts/r_leg = 1,
 				/obj/item/stack/sheet/metal = 1,
 				/obj/item/stack/cable_coil = 1,
-				/obj/item/gun/energy/gun/advtaser = 1,
+				/obj/item/gun/energy/disabler = 1,
 				/obj/item/stock_parts/cell = 1,
 				/obj/item/assembly/prox_sensor = 1)
 	tools = list(TOOL_WELDER, TOOL_SCREWDRIVER)

--- a/code/modules/examine/descriptions/weapons.dm
+++ b/code/modules/examine/descriptions/weapons.dm
@@ -23,9 +23,9 @@
 	description_info = "This is an energy weapon. Most energy weapons can fire through windows harmlessly.  To switch between stun and lethal, click the weapon \
 	in your hand.  To recharge this weapon, use a weapon recharger."
 
-/obj/item/gun/energy/gun/advtaser
-	description_info = "This is an energy weapon. To recharge this weapon, use a weapon recharger. \
-	To switch between insta-stun and disabler beams, click the weapon in your hand. This weapon can only fire through glass if it is set to disabler beams."
+// /obj/item/gun/energy/gun/advtaser
+// 	description_info = "This is an energy weapon. To recharge this weapon, use a weapon recharger. \
+// 	To switch between insta-stun and disabler beams, click the weapon in your hand. This weapon can only fire through glass if it is set to disabler beams."
 
 /obj/item/gun/energy/nuclear
 	description_info = "This is an energy weapon. Most energy weapons can fire through windows harmlessly.  To switch between stun and lethal, click the weapon \

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -155,9 +155,9 @@
 						return
 					newname = "redtag ED-209 assembly"
 				if("")
-					if(!istype(W, /obj/item/gun/energy/gun/advtaser))
+					if(!istype(W, /obj/item/gun/energy/disabler))
 						return
-					newname = "taser ED-209 assembly"
+					newname = "disabler ED-209 assembly"
 				else
 					return
 			if(!user.unEquip(W))

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -396,7 +396,7 @@
 	new /obj/item/assembly/prox_sensor(Tsec)
 
 	if(!lasercolor)
-		var/obj/item/gun/energy/gun/advtaser/G = new /obj/item/gun/energy/gun/advtaser(Tsec)
+		var/obj/item/gun/energy/disabler/G = new /obj/item/gun/energy/disabler(Tsec)
 		G.cell.charge = 0
 		G.update_icon()
 	else if(lasercolor == "b")

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -96,21 +96,21 @@
 	// Used by gamma ERT borgs
 	e_cost = 1000 // 5x that of the standard laser, for 7.5x the damage (if 6/6 shots hit) plus ignite. Efficient only if you hit with at least 4/6 of the shots.
 
-/obj/item/ammo_casing/energy/electrode
-	projectile_type = /obj/item/projectile/energy/electrode
-	muzzle_flash_color = "#FFFF00"
-	select_name = "stun"
-	fire_sound = 'sound/weapons/taser.ogg'
-	e_cost = 200
-	delay = 15
-	harmful = FALSE
+// /obj/item/ammo_casing/energy/electrode
+// 	projectile_type = /obj/item/projectile/energy/electrode
+// 	muzzle_flash_color = "#FFFF00"
+// 	select_name = "stun"
+// 	fire_sound = 'sound/weapons/taser.ogg'
+// 	e_cost = 200
+// 	delay = 15
+// 	harmful = FALSE
 
-/obj/item/ammo_casing/energy/electrode/gun
-	fire_sound = 'sound/weapons/gunshots/gunshot.ogg'
-	e_cost = 100
+// /obj/item/ammo_casing/energy/electrode/gun
+// 	fire_sound = 'sound/weapons/gunshots/gunshot.ogg'
+// 	e_cost = 100
 
-/obj/item/ammo_casing/energy/electrode/hos //allows balancing of HoS and blueshit guns seperately from other energy weapons
-	e_cost = 200
+// /obj/item/ammo_casing/energy/electrode/hos //allows balancing of HoS and blueshit guns seperately from other energy weapons
+// 	e_cost = 200
 
 /obj/item/ammo_casing/energy/ion
 	projectile_type = /obj/item/projectile/ion

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -44,21 +44,21 @@
 
 /obj/item/gun/energy/gun/hos
 	name = "\improper X-01 MultiPhase Energy Gun"
-	desc = "This is an expensive, modern recreation of an antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time."
+	desc = "This is an expensive, modern recreation of an antique laser gun. This gun has two firemodes, but lacks the ability to recharge over time."
 	icon_state = "hoslaser"
 	origin_tech = null
 	force = 10
-	ammo_type = list(/obj/item/ammo_casing/energy/electrode/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/disabler)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 4
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/gun/energy/gun/blueshield
 	name = "advanced stun revolver"
-	desc = "An advanced stun revolver with the capacity to shoot both electrodes and lasers."
+	desc = "An advanced stun revolver with the capacity to shoot both disablers and lasers."
 	icon_state = "bsgun"
 	item_state = "gun"
 	force = 7
-	ammo_type = list(/obj/item/ammo_casing/energy/electrode/hos, /obj/item/ammo_casing/energy/laser/hos)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 1
 	shaded_charge = 1
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -1,11 +1,11 @@
-/obj/item/gun/energy/taser
-	name = "taser gun"
-	desc = "A small, low capacity gun used for non-lethal takedowns."
-	icon_state = "taser"
-	item_state = null	//so the human update icon uses the icon_state instead.
-	origin_tech = "combat=3"
-	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
-	ammo_x_offset = 3
+// /obj/item/gun/energy/taser
+// 	name = "taser gun"
+// 	desc = "A small, low capacity gun used for non-lethal takedowns."
+// 	icon_state = "taser"
+// 	item_state = null // so the human update icon uses the icon_state instead.
+// 	origin_tech = "combat=3"
+// 	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
+// 	ammo_x_offset = 3
 
 /obj/item/gun/energy/shock_revolver
 	name = "tesla revolver"
@@ -17,23 +17,23 @@
 	can_flashlight = 0
 	shaded_charge = 1
 
-/obj/item/gun/energy/gun/advtaser
-	name = "hybrid taser"
-	desc = "A dual-mode taser designed to fire both short-range high-power electrodes and long-range disabler beams."
-	icon_state = "advtaser"
-	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/disabler)
-	origin_tech = "combat=4"
-	ammo_x_offset = 2
+// /obj/item/gun/energy/gun/advtaser
+// 	name = "hybrid taser"
+// 	desc = "A dual-mode taser designed to fire both short-range high-power electrodes and long-range disabler beams."
+// 	icon_state = "advtaser"
+// 	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/disabler)
+// 	origin_tech = "combat=4"
+// 	ammo_x_offset = 2
 
-/obj/item/gun/energy/gun/advtaser/cyborg
-	name = "cyborg taser"
-	desc = "An integrated hybrid taser that draws directly from a cyborg's power cell. The weapon contains a limiter to prevent the cyborg's power cell from overheating."
-	can_flashlight = 0
-	can_charge = 0
+// /obj/item/gun/energy/gun/advtaser/cyborg
+// 	name = "cyborg taser"
+// 	desc = "An integrated hybrid taser that draws directly from a cyborg's power cell. The weapon contains a limiter to prevent the cyborg's power cell from overheating."
+// 	can_flashlight = 0
+// 	can_charge = 0
 
-/obj/item/gun/energy/gun/advtaser/cyborg/newshot()
-	..()
-	robocharge()
+// /obj/item/gun/energy/gun/advtaser/cyborg/newshot()
+// 	..()
+// 	robocharge()
 
 /obj/item/gun/energy/disabler
 	name = "disabler"

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -1,13 +1,13 @@
-/obj/item/gun/energy/gun/advtaser/mounted
-	name = "mounted taser"
-	desc = "An arm mounted dual-mode weapon that fires electrodes and disabler shots."
-	icon = 'icons/obj/items_cyborg.dmi'
-	icon_state = "taser"
-	item_state = "armcannonstun4"
-	force = 5
-	selfcharge = 1
-	can_flashlight = 0
-	trigger_guard = TRIGGER_GUARD_ALLOW_ALL // Has no trigger at all, uses neural signals instead
+// /obj/item/gun/energy/gun/advtaser/mounted
+// 	name = "mounted taser"
+// 	desc = "An arm mounted dual-mode weapon that fires electrodes and disabler shots."
+// 	icon = 'icons/obj/items_cyborg.dmi'
+// 	icon_state = "taser"
+// 	item_state = "armcannonstun4"
+// 	force = 5
+// 	selfcharge = 1
+// 	can_flashlight = 0
+// 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL // Has no trigger at all, uses neural signals instead
 
 /obj/item/gun/energy/laser/mounted
 	name = "mounted laser"

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -138,7 +138,7 @@
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/color/black
 	suit = /obj/item/clothing/suit/armor/vest/ert/security
-	suit_store = /obj/item/gun/energy/gun/advtaser
+	suit_store = /obj/item/gun/projectile/automatic/pistol/enforcer
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	mask = /obj/item/clothing/mask/gas/sechailer
 
@@ -440,7 +440,7 @@
 	name = "RT Paranormal (Amber)"
 	suit = /obj/item/clothing/suit/armor/vest/ert/security/paranormal
 	head = /obj/item/clothing/head/helmet/ert/security/paranormal
-	suit_store = /obj/item/gun/energy/gun/advtaser
+	suit_store = /obj/item/gun/projectile/automatic/pistol/enforcer
 	r_pocket = /obj/item/nullrod
 
 /datum/outfit/job/centcom/response_team/paranormal/red

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -182,15 +182,15 @@
 /obj/item/organ/internal/cyberimp/arm/gun/laser/l
 	parent_organ = "l_arm"
 
-/obj/item/organ/internal/cyberimp/arm/gun/taser
-	name = "arm-mounted taser implant"
-	desc = "A variant of the arm cannon implant that fires electrodes and disabler shots. The cannon emerges from the subject's arm and remains inside when not in use."
-	icon_state = "arm_taser"
-	origin_tech = "materials=5;combat=5;biotech=4;powerstorage=4"
-	contents = newlist(/obj/item/gun/energy/gun/advtaser/mounted)
-
-/obj/item/organ/internal/cyberimp/arm/gun/taser/l
-	parent_organ = "l_arm"
+// /obj/item/organ/internal/cyberimp/arm/gun/taser
+// 	name = "arm-mounted taser implant"
+// 	desc = "A variant of the arm cannon implant that fires electrodes and disabler shots. The cannon emerges from the subject's arm and remains inside when not in use."
+// 	icon_state = "arm_taser"
+// 	origin_tech = "materials=5;combat=5;biotech=4;powerstorage=4"
+// 	contents = newlist(/obj/item/gun/energy/gun/advtaser/mounted)
+//
+// /obj/item/organ/internal/cyberimp/arm/gun/taser/l
+// 	parent_organ = "l_arm"
 
 
 /obj/item/organ/internal/cyberimp/arm/toolset


### PR DESCRIPTION
## What Does This PR Do
In what is sure to be a universally accepted PR with no controversy whatsoever, this removes Tasers from the game.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The golden bolt of `Haha, I Win!` has been the scourge of antagonists with a desire to role-play with security; they are instead immediately stunned, wordlessly thrown in permabrig, and removed from the round.

No more tasers. Security will have to work for that victory while being taunted by antagonists.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Security now has a non-lethal Enforcer 
del: Tasers are removed from the game.
experiment: A different style of combat? Unpossible!
/:cl:
