### PR TITLE
Fixes Map Voting when Emergency Shuttle docks

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -232,7 +232,7 @@
 				timer = world.time
 				emergency_shuttle_docked.Announce("The Emergency Shuttle has docked with the station. You have [timeLeft(600)] minutes to board the Emergency Shuttle.")
 				// ask the players which map they want to play on next
-				INVOKE_ASYNC(SSvote, /datum/controller/subsystem/vote/.proc/initiate_vote, VOTE_TYPE_MAP, "the server")
+				INVOKE_ASYNC(SSvote, /datum/controller/subsystem/vote/.proc/start_vote_for_next_map)
 
 /*
 				//Gangs only have one attempt left if the shuttle has docked with the station to prevent suffering from dominator delays


### PR DESCRIPTION
## What Does This PR Do
After some debug logging #369, it became clear that the map vote was being held too soon after the automatic crew transfer vote. As a result, map voting would only occur when the shuttle was called by the players.

This PR fixes that, allowing server initiated votes like automatic crew transfer and next map voting to bypass the time check.
The debug logging introduced in #369 was also cleaned up a bit to provide info-level logging for votes during the game.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A functional map vote system enables more maps to be used in a reliable way. This will be important as Scorpio develops its distinct niche.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Map Voting will occur when the Emergency Shuttle docks with the station.
/:cl:
