### PR TITLE
SMES Supercharge vote takes Supermatter Crystal into consideration

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -472,17 +472,24 @@ SUBSYSTEM_DEF(vote)
 /**
   * Determine if the station has power.
   *
-  * Actually, we'll just cheat and see if the Particle Accelerator is active.
-  * If the Particle Accelerator is active, we'll assume that we have power.
+  * Actually, we'll just cheat and see if the engine is active.
+  * If the engine is active, we'll assume that we have power.
+  *
+  * If we can't find the engine, we'll assume that we don't have power.
   * See: https://www.youtube.com/watch?v=-dJolYw8tnk
   */
 /proc/i_have_the_power()
-	var/obj/machinery/particle_accelerator/control_box/the_pa = locate("particle_accelerator_control_box")
-	if(!the_pa)
-		log_and_message_admins("Unable to locate Particle Accelerator Control Console on this map.")
-		log_and_message_admins("Missing tag: particle_accelerator_control_box")
-		return FALSE
-	return the_pa.active
+	// if we find a particle accelerator control box, we have power if it is turned on
+	var/obj/machinery/particle_accelerator/control_box/the_pa = locate()
+	if(the_pa)
+		return the_pa.active
+	// if we find a supermatter crystal, we have power if the main engine has been powered
+	var/obj/machinery/power/supermatter_crystal/the_sm = locate()
+	if(the_sm)
+		return the_sm.is_main_engine && the_sm.has_been_powered
+	// otherwise, tell the admins we couldn't find it, and say we don't have power
+	log_and_message_admins("Unable to locate Particle Accelerator Control Console or Supermatter Crystal on this map.")
+	return FALSE
 
 #undef VOTE_SUPERCHARGE_NO
 #undef VOTE_SUPERCHARGE_YES


### PR DESCRIPTION
## What Does This PR Do
Modifies the SMES Supercharge vote to take a Supermatter Crystal into consideration as a power source.
When using alternate maps (especially upstream maps) an active Supermatter engine was not considered a power source.
This allows the code to detect a running Supermatter engine and override the vote to supercharge the SMES for the round.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No need to supercharge the SMES when an engineer has set up a running Supermatter engine.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Supercharge vote will not happen when an active Supermatter engine is detected.
/:cl:
