### PR TITLE
More Cargo Shuttle Conveyor Belts and Doors

### DIFF
--- a/_maps/map_files/emerald/z2.dmm
+++ b/_maps/map_files/emerald/z2.dmm
@@ -37536,11 +37536,11 @@ qI
 Jn
 Nq
 Nq
+Gd
+yE
 Nq
-Nq
-Nq
-Nq
-Nq
+yE
+Zh
 Nq
 Nq
 pn


### PR DESCRIPTION
## What Does This PR Do
Adds conveyor belts and doors to the west side of the Cargo shuttle.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to load and unload the cargo shuttle without a hardsuit and a space-walk is handy!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cargo Shuttle may be loaded from the west side
/:cl: