### PR TITLE
Cloning Console Tweak - No More Remote Vitals Tracking

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -249,12 +249,13 @@
 					qdel(active_record)
 					set_temp("Error: Record corrupt.", "danger")
 				else
-					var/obj/item/implant/health/H = null
-					if(active_record.implant)
-						H = locate(active_record.implant)
+					var/healthstring = "No Vitals Data Available"
+					if(ishuman(scanner.occupant))
+						var/mob/living/carbon/human/M = scanner.occupant
+						healthstring = "[round(M.getOxyLoss())] - [round(M.getFireLoss())] - [round(M.getToxLoss())] - [round(M.getBruteLoss())]"
 					var/list/payload = list(
 						activerecord = "\ref[active_record]",
-						health = (H && istype(H)) ? H.sensehealth() : "",
+						health = sanitize(healthstring),
 						realname = sanitize(active_record.dna.real_name),
 						unidentity = active_record.dna.uni_identity,
 						strucenzymes = active_record.dna.struc_enzymes,
@@ -346,8 +347,6 @@
 							set_temp("Initiating cloning cycle...", "success")
 							records.Remove(C)
 							qdel(C)
-							active_record = pod.occupant
-							SStgui.update_uis(src)
 							menu = MENU_MAIN
 						else
 							set_temp("Error: Initialisation failure.", "danger")
@@ -374,7 +373,7 @@
 
 	src.add_fingerprint(usr)
 
-/obj/machinery/computer/cloning/proc/scan_mob(mob/living/carbon/human/subject as mob, var/scan_brain = 0)
+/obj/machinery/computer/cloning/proc/scan_mob(mob/living/carbon/human/subject, var/scan_brain = 0)
 	if(stat & NOPOWER)
 		return
 	if(scanner.stat & (NOPOWER|BROKEN))
@@ -446,12 +445,6 @@
 
 	R.types=DNA2_BUF_UI|DNA2_BUF_UE|DNA2_BUF_SE
 	R.languages=subject.languages
-	//Add an implant if needed
-	var/obj/item/implant/health/imp = locate(/obj/item/implant/health, subject)
-	if(!imp)
-		imp = new /obj/item/implant/health(subject)
-		imp.implant(subject)
-	R.implant = "\ref[imp]"
 
 	if(!isnull(subject.mind)) //Save that mind so traitors can continue traitoring after cloning.
 		R.mind = "\ref[subject.mind]"

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -346,6 +346,8 @@
 							set_temp("Initiating cloning cycle...", "success")
 							records.Remove(C)
 							qdel(C)
+							active_record = pod.occupant
+							SStgui.update_uis(src)
 							menu = MENU_MAIN
 						else
 							set_temp("Error: Initialisation failure.", "danger")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
- Fixes Issue https://github.com/ScorpioStation/ScorpioStation/issues/375
- Removes the use of the Health Implant from the cloning console
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Before changing this:

> This makes for a very easily exploitable system of monitoring patients health - granted you have to scan someone beforehand, sure, but once you do, and you'll avoid letting people delete the records, you'll be able to monitor the patient's vitals no matter the time and place or even if they have any sensors on at all.

- After changing this, the only way to see the vitals of a Cloning Scanner occupant is while the occupant is in the scanner.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
Looking at the Records when the Mob is inside the Scanner:
![image](https://user-images.githubusercontent.com/69871346/109370314-ce217680-786d-11eb-8d93-217d826af521.png)

Looking at the Records when the Mob is outside of the Scanner:
![image](https://user-images.githubusercontent.com/69871346/109370285-ad592100-786d-11eb-864a-183fb7af79ac.png)

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Cloning Scanner no longer secretly implants you with a secret implant that was secretly tracking your vitals remotely, regardless of your suit sensors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
